### PR TITLE
Enable parallel instances of the ILibiMobileDevice API to co-exist (for unit testing)

### DIFF
--- a/iMobileDevice.Generator/ApiGenerator.cs
+++ b/iMobileDevice.Generator/ApiGenerator.cs
@@ -122,7 +122,8 @@ namespace iMobileDevice.Generator
                             new CodeThisReferenceExpression(),
                             camelCased),
                         new CodeObjectCreateExpression(
-                            new CodeTypeReference($"{name}Api"))));
+                            new CodeTypeReference($"{name}Api"),
+                            new CodeThisReferenceExpression())));
             }
 
             // Add the LibraryFound property

--- a/iMobileDevice.Generator/CodeDom/CSharpTextWriter.Members.cs
+++ b/iMobileDevice.Generator/CodeDom/CSharpTextWriter.Members.cs
@@ -48,8 +48,12 @@
                 this.Indent--;
                 this.WriteLine("}");
             }
+            else if (property.HasGet)
+            {
+                this.WriteLine("get;");
+            }
 
-            if (property.GetStatements != null && property.SetStatements.Count > 0)
+            if (property.SetStatements != null && property.SetStatements.Count > 0)
             {
                 this.WriteLine("set");
                 this.WriteLine("{");
@@ -59,6 +63,10 @@
 
                 this.Indent--;
                 this.WriteLine("}");
+            }
+            else if (property.HasSet)
+            {
+                this.WriteLine("set;");
             }
 
             this.Indent--;

--- a/iMobileDevice.Generator/CodeDom/CSharpTextWriter.Statements.cs
+++ b/iMobileDevice.Generator/CodeDom/CSharpTextWriter.Statements.cs
@@ -44,10 +44,29 @@
             {
                 this.Generate((CodeThrowExceptionStatement)statement);
             }
+            else if (statement is CodeCommentStatement)
+            {
+                this.Generate((CodeCommentStatement)statement);
+            }
             else
             {
                 throw new NotSupportedException();
             }
+        }
+
+        private void Generate(CodeCommentStatement statement)
+        {
+            if (statement.Comment.DocComment)
+            {
+                this.Write("/// ");
+            }
+            else
+            {
+                this.Write("// ");
+            }
+
+            this.Write(statement.Comment.Text);
+            this.WriteLine();
         }
 
         private void Generate(CodeThrowExceptionStatement statement)

--- a/iMobileDevice.Generator/FunctionVisitor.cs
+++ b/iMobileDevice.Generator/FunctionVisitor.cs
@@ -97,7 +97,7 @@ namespace iMobileDevice.Generator
             {
                 functionKind = FunctionType.Free;
             }
-            else if(nativeName.Contains("pinvoke"))
+            else if (nativeName.Contains("pinvoke"))
             {
                 functionKind = FunctionType.PInvoke;
             }

--- a/iMobileDevice.Generator/ModuleGenerator.cs
+++ b/iMobileDevice.Generator/ModuleGenerator.cs
@@ -215,9 +215,9 @@ namespace iMobileDevice.Generator
                                     new CodeMethodReferenceExpression(
                                     new CodePropertyReferenceExpression(
                                         new CodePropertyReferenceExpression(
-                                            new CodeTypeReferenceExpression("LibiMobileDevice"),
-                                            "Instance"),
-                                        this.Name),
+                                            new CodeThisReferenceExpression(),
+                                            "Api"),
+                                            this.Name),
                                     freeMethod.Name),
                                     new CodeFieldReferenceExpression(
                                         new CodeThisReferenceExpression(),

--- a/iMobileDevice.Generator/Program.cs
+++ b/iMobileDevice.Generator/Program.cs
@@ -14,8 +14,27 @@ namespace iMobileDevice.Generator
     {
         public static void Main(string[] args)
         {
-            var sourceDirectory = args[0];
-            var targetDirectory = args[1];
+            string sourceDirectory = null; ;
+            string targetDirectory = null;
+
+            if (args.Length >= 1)
+            {
+                sourceDirectory = args[0];
+            }
+            else
+            {
+                // Default value so that you can just F5 from within Visual Studio
+                sourceDirectory = @"..\..\..\..\";
+            }
+
+            if (args.Length >= 2)
+            {
+                targetDirectory = args[1];
+            }
+            else
+            {
+                targetDirectory = @"..\..\..\..\iMobileDevice";
+            }
 
             sourceDirectory = Path.GetFullPath(sourceDirectory);
             targetDirectory = Path.GetFullPath(targetDirectory);

--- a/iMobileDevice.Generator/TypeDefVisitor.cs
+++ b/iMobileDevice.Generator/TypeDefVisitor.cs
@@ -51,7 +51,7 @@ namespace iMobileDevice.Generator
                     var pointee = clang.getPointeeType(type);
                     if (pointee.kind == CXTypeKind.CXType_Record || pointee.kind == CXTypeKind.CXType_Void)
                     {
-                        var types = Handles.CreateSafeHandle(clrName).ToArray();
+                        var types = Handles.CreateSafeHandle(clrName, this.generator).ToArray();
                         this.generator.AddType(nativeName, types[0]);
 
                         for (int i = 1; i < types.Length; i++)

--- a/iMobileDevice/Afc/AfcApi.cs
+++ b/iMobileDevice/Afc/AfcApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.Afc
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"AfcApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Afc"/>.
+        /// </summary>
+        public AfcApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Makes a connection to the AFC service on the device.
         /// </summary>
         /// <param name="device">
@@ -35,7 +60,10 @@ namespace iMobileDevice.Afc
         /// </returns>
         public virtual AfcError afc_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out AfcClientHandle client)
         {
-            return AfcNativeMethods.afc_client_new(device, service, out client);
+            AfcError returnValue;
+            returnValue = AfcNativeMethods.afc_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -57,7 +85,10 @@ namespace iMobileDevice.Afc
         /// </returns>
         public virtual AfcError afc_client_start_service(iDeviceHandle device, out AfcClientHandle client, string label)
         {
-            return AfcNativeMethods.afc_client_start_service(device, out client, label);
+            AfcError returnValue;
+            returnValue = AfcNativeMethods.afc_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/Afc/AfcClientHandle.cs
+++ b/iMobileDevice/Afc/AfcClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.Afc
     public partial class AfcClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected AfcClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.Afc
         protected AfcClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static AfcClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.Afc
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.Afc.afc_client_free(this.handle) == AfcError.Success);
+            return (this.Api.Afc.afc_client_free(this.handle) == AfcError.Success);
         }
         
         public static AfcClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/Afc/IAfcApi.cs
+++ b/iMobileDevice/Afc/IAfcApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.Afc
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Afc"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Makes a connection to the AFC service on the device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/DebugServer/DebugServerApi.cs
+++ b/iMobileDevice/DebugServer/DebugServerApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.DebugServer
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"DebugServerApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="DebugServer"/>.
+        /// </summary>
+        public DebugServerApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the debugserver service on the specified device.
         /// </summary>
         /// <param name="device">
@@ -35,7 +60,10 @@ namespace iMobileDevice.DebugServer
         /// </returns>
         public virtual DebugServerError debugserver_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out DebugServerClientHandle client)
         {
-            return DebugServerNativeMethods.debugserver_client_new(device, service, out client);
+            DebugServerError returnValue;
+            returnValue = DebugServerNativeMethods.debugserver_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -59,7 +87,10 @@ namespace iMobileDevice.DebugServer
         /// </returns>
         public virtual DebugServerError debugserver_client_start_service(iDeviceHandle device, out DebugServerClientHandle client, string label)
         {
-            return DebugServerNativeMethods.debugserver_client_start_service(device, out client, label);
+            DebugServerError returnValue;
+            returnValue = DebugServerNativeMethods.debugserver_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -285,7 +316,10 @@ namespace iMobileDevice.DebugServer
         /// </returns>
         public virtual DebugServerError debugserver_command_new(string name, int argc, System.Collections.ObjectModel.ReadOnlyCollection<string> argv, out DebugServerCommandHandle command)
         {
-            return DebugServerNativeMethods.debugserver_command_new(name, argc, argv, out command);
+            DebugServerError returnValue;
+            returnValue = DebugServerNativeMethods.debugserver_command_new(name, argc, argv, out command);
+            command.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/DebugServer/DebugServerClientHandle.cs
+++ b/iMobileDevice/DebugServer/DebugServerClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.DebugServer
     public partial class DebugServerClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected DebugServerClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.DebugServer
         protected DebugServerClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static DebugServerClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.DebugServer
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.DebugServer.debugserver_client_free(this.handle) == DebugServerError.Success);
+            return (this.Api.DebugServer.debugserver_client_free(this.handle) == DebugServerError.Success);
         }
         
         public static DebugServerClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/DebugServer/DebugServerCommandHandle.cs
+++ b/iMobileDevice/DebugServer/DebugServerCommandHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.DebugServer
     public partial class DebugServerCommandHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected DebugServerCommandHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.DebugServer
         protected DebugServerCommandHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static DebugServerCommandHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.DebugServer
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.DebugServer.debugserver_command_free(this.handle) == DebugServerError.Success);
+            return (this.Api.DebugServer.debugserver_command_free(this.handle) == DebugServerError.Success);
         }
         
         public static DebugServerCommandHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/DebugServer/IDebugServerApi.cs
+++ b/iMobileDevice/DebugServer/IDebugServerApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.DebugServer
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="DebugServer"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the debugserver service on the specified device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/DiagnosticsRelay/DiagnosticsRelayApi.cs
+++ b/iMobileDevice/DiagnosticsRelay/DiagnosticsRelayApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.DiagnosticsRelay
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"DiagnosticsRelayApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="DiagnosticsRelay"/>.
+        /// </summary>
+        public DiagnosticsRelayApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the diagnostics_relay service on the specified device.
         /// </summary>
         /// <param name="device">
@@ -35,7 +60,10 @@ namespace iMobileDevice.DiagnosticsRelay
         /// </returns>
         public virtual DiagnosticsRelayError diagnostics_relay_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out DiagnosticsRelayClientHandle client)
         {
-            return DiagnosticsRelayNativeMethods.diagnostics_relay_client_new(device, service, out client);
+            DiagnosticsRelayError returnValue;
+            returnValue = DiagnosticsRelayNativeMethods.diagnostics_relay_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -59,7 +87,10 @@ namespace iMobileDevice.DiagnosticsRelay
         /// </returns>
         public virtual DiagnosticsRelayError diagnostics_relay_client_start_service(iDeviceHandle device, out DiagnosticsRelayClientHandle client, string label)
         {
-            return DiagnosticsRelayNativeMethods.diagnostics_relay_client_start_service(device, out client, label);
+            DiagnosticsRelayError returnValue;
+            returnValue = DiagnosticsRelayNativeMethods.diagnostics_relay_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -183,22 +214,34 @@ namespace iMobileDevice.DiagnosticsRelay
         /// </returns>
         public virtual DiagnosticsRelayError diagnostics_relay_request_diagnostics(DiagnosticsRelayClientHandle client, string type, out PlistHandle diagnostics)
         {
-            return DiagnosticsRelayNativeMethods.diagnostics_relay_request_diagnostics(client, type, out diagnostics);
+            DiagnosticsRelayError returnValue;
+            returnValue = DiagnosticsRelayNativeMethods.diagnostics_relay_request_diagnostics(client, type, out diagnostics);
+            diagnostics.Api = this.Parent;
+            return returnValue;
         }
         
         public virtual DiagnosticsRelayError diagnostics_relay_query_mobilegestalt(DiagnosticsRelayClientHandle client, PlistHandle keys, out PlistHandle result)
         {
-            return DiagnosticsRelayNativeMethods.diagnostics_relay_query_mobilegestalt(client, keys, out result);
+            DiagnosticsRelayError returnValue;
+            returnValue = DiagnosticsRelayNativeMethods.diagnostics_relay_query_mobilegestalt(client, keys, out result);
+            result.Api = this.Parent;
+            return returnValue;
         }
         
         public virtual DiagnosticsRelayError diagnostics_relay_query_ioregistry_entry(DiagnosticsRelayClientHandle client, string name, string classname, out PlistHandle result)
         {
-            return DiagnosticsRelayNativeMethods.diagnostics_relay_query_ioregistry_entry(client, name, classname, out result);
+            DiagnosticsRelayError returnValue;
+            returnValue = DiagnosticsRelayNativeMethods.diagnostics_relay_query_ioregistry_entry(client, name, classname, out result);
+            result.Api = this.Parent;
+            return returnValue;
         }
         
         public virtual DiagnosticsRelayError diagnostics_relay_query_ioregistry_plane(DiagnosticsRelayClientHandle client, string plane, out PlistHandle result)
         {
-            return DiagnosticsRelayNativeMethods.diagnostics_relay_query_ioregistry_plane(client, plane, out result);
+            DiagnosticsRelayError returnValue;
+            returnValue = DiagnosticsRelayNativeMethods.diagnostics_relay_query_ioregistry_plane(client, plane, out result);
+            result.Api = this.Parent;
+            return returnValue;
         }
     }
 }

--- a/iMobileDevice/DiagnosticsRelay/DiagnosticsRelayClientHandle.cs
+++ b/iMobileDevice/DiagnosticsRelay/DiagnosticsRelayClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.DiagnosticsRelay
     public partial class DiagnosticsRelayClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected DiagnosticsRelayClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.DiagnosticsRelay
         protected DiagnosticsRelayClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static DiagnosticsRelayClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.DiagnosticsRelay
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.DiagnosticsRelay.diagnostics_relay_client_free(this.handle) == DiagnosticsRelayError.Success);
+            return (this.Api.DiagnosticsRelay.diagnostics_relay_client_free(this.handle) == DiagnosticsRelayError.Success);
         }
         
         public static DiagnosticsRelayClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/DiagnosticsRelay/IDiagnosticsRelayApi.cs
+++ b/iMobileDevice/DiagnosticsRelay/IDiagnosticsRelayApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.DiagnosticsRelay
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="DiagnosticsRelay"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the diagnostics_relay service on the specified device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/FileRelay/FileRelayApi.cs
+++ b/iMobileDevice/FileRelay/FileRelayApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.FileRelay
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"FileRelayApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="FileRelay"/>.
+        /// </summary>
+        public FileRelayApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the file_relay service on the specified device.
         /// </summary>
         /// <param name="device">
@@ -35,7 +60,10 @@ namespace iMobileDevice.FileRelay
         /// </returns>
         public virtual FileRelayError file_relay_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out FileRelayClientHandle client)
         {
-            return FileRelayNativeMethods.file_relay_client_new(device, service, out client);
+            FileRelayError returnValue;
+            returnValue = FileRelayNativeMethods.file_relay_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -59,7 +87,10 @@ namespace iMobileDevice.FileRelay
         /// </returns>
         public virtual FileRelayError file_relay_client_start_service(iDeviceHandle device, out FileRelayClientHandle client, string label)
         {
-            return FileRelayNativeMethods.file_relay_client_start_service(device, out client, label);
+            FileRelayError returnValue;
+            returnValue = FileRelayNativeMethods.file_relay_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -122,7 +153,10 @@ namespace iMobileDevice.FileRelay
         /// </remarks>
         public virtual FileRelayError file_relay_request_sources(FileRelayClientHandle client, out string sources, out iDeviceConnectionHandle connection)
         {
-            return FileRelayNativeMethods.file_relay_request_sources(client, out sources, out connection);
+            FileRelayError returnValue;
+            returnValue = FileRelayNativeMethods.file_relay_request_sources(client, out sources, out connection);
+            connection.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -165,7 +199,10 @@ namespace iMobileDevice.FileRelay
         /// </remarks>
         public virtual FileRelayError file_relay_request_sources_timeout(FileRelayClientHandle client, out string sources, out iDeviceConnectionHandle connection, uint timeout)
         {
-            return FileRelayNativeMethods.file_relay_request_sources_timeout(client, out sources, out connection, timeout);
+            FileRelayError returnValue;
+            returnValue = FileRelayNativeMethods.file_relay_request_sources_timeout(client, out sources, out connection, timeout);
+            connection.Api = this.Parent;
+            return returnValue;
         }
     }
 }

--- a/iMobileDevice/FileRelay/FileRelayClientHandle.cs
+++ b/iMobileDevice/FileRelay/FileRelayClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.FileRelay
     public partial class FileRelayClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected FileRelayClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.FileRelay
         protected FileRelayClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static FileRelayClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.FileRelay
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.FileRelay.file_relay_client_free(this.handle) == FileRelayError.Success);
+            return (this.Api.FileRelay.file_relay_client_free(this.handle) == FileRelayError.Success);
         }
         
         public static FileRelayClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/FileRelay/IFileRelayApi.cs
+++ b/iMobileDevice/FileRelay/IFileRelayApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.FileRelay
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="FileRelay"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the file_relay service on the specified device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/HeartBeat/HeartBeatApi.cs
+++ b/iMobileDevice/HeartBeat/HeartBeatApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.HeartBeat
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"HeartBeatApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="HeartBeat"/>.
+        /// </summary>
+        public HeartBeatApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the heartbeat service on the specified device.
         /// </summary>
         /// <param name="device">
@@ -35,7 +60,10 @@ namespace iMobileDevice.HeartBeat
         /// </returns>
         public virtual HeartBeatError heartbeat_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out HeartBeatClientHandle client)
         {
-            return HeartBeatNativeMethods.heartbeat_client_new(device, service, out client);
+            HeartBeatError returnValue;
+            returnValue = HeartBeatNativeMethods.heartbeat_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -59,7 +87,10 @@ namespace iMobileDevice.HeartBeat
         /// </returns>
         public virtual HeartBeatError heartbeat_client_start_service(iDeviceHandle device, out HeartBeatClientHandle client, string label)
         {
-            return HeartBeatNativeMethods.heartbeat_client_start_service(device, out client, label);
+            HeartBeatError returnValue;
+            returnValue = HeartBeatNativeMethods.heartbeat_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -111,7 +142,10 @@ namespace iMobileDevice.HeartBeat
         /// </returns>
         public virtual HeartBeatError heartbeat_receive(HeartBeatClientHandle client, out PlistHandle plist)
         {
-            return HeartBeatNativeMethods.heartbeat_receive(client, out plist);
+            HeartBeatError returnValue;
+            returnValue = HeartBeatNativeMethods.heartbeat_receive(client, out plist);
+            plist.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -137,7 +171,10 @@ namespace iMobileDevice.HeartBeat
         /// </returns>
         public virtual HeartBeatError heartbeat_receive_with_timeout(HeartBeatClientHandle client, out PlistHandle plist, uint timeoutMs)
         {
-            return HeartBeatNativeMethods.heartbeat_receive_with_timeout(client, out plist, timeoutMs);
+            HeartBeatError returnValue;
+            returnValue = HeartBeatNativeMethods.heartbeat_receive_with_timeout(client, out plist, timeoutMs);
+            plist.Api = this.Parent;
+            return returnValue;
         }
     }
 }

--- a/iMobileDevice/HeartBeat/HeartBeatClientHandle.cs
+++ b/iMobileDevice/HeartBeat/HeartBeatClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.HeartBeat
     public partial class HeartBeatClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected HeartBeatClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.HeartBeat
         protected HeartBeatClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static HeartBeatClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.HeartBeat
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.HeartBeat.heartbeat_client_free(this.handle) == HeartBeatError.Success);
+            return (this.Api.HeartBeat.heartbeat_client_free(this.handle) == HeartBeatError.Success);
         }
         
         public static HeartBeatClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/HeartBeat/IHeartBeatApi.cs
+++ b/iMobileDevice/HeartBeat/IHeartBeatApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.HeartBeat
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="HeartBeat"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the heartbeat service on the specified device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/HouseArrest/HouseArrestApi.cs
+++ b/iMobileDevice/HouseArrest/HouseArrestApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.HouseArrest
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"HouseArrestApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="HouseArrest"/>.
+        /// </summary>
+        public HouseArrestApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the house_arrest service on the specified device.
         /// </summary>
         /// <param name="device">
@@ -34,7 +59,10 @@ namespace iMobileDevice.HouseArrest
         /// </returns>
         public virtual HouseArrestError house_arrest_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out HouseArrestClientHandle client)
         {
-            return HouseArrestNativeMethods.house_arrest_client_new(device, service, out client);
+            HouseArrestError returnValue;
+            returnValue = HouseArrestNativeMethods.house_arrest_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -58,7 +86,10 @@ namespace iMobileDevice.HouseArrest
         /// </returns>
         public virtual HouseArrestError house_arrest_client_start_service(iDeviceHandle device, out HouseArrestClientHandle client, string label)
         {
-            return HouseArrestNativeMethods.house_arrest_client_start_service(device, out client, label);
+            HouseArrestError returnValue;
+            returnValue = HouseArrestNativeMethods.house_arrest_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -159,7 +190,10 @@ namespace iMobileDevice.HouseArrest
         /// </returns>
         public virtual HouseArrestError house_arrest_get_result(HouseArrestClientHandle client, out PlistHandle dict)
         {
-            return HouseArrestNativeMethods.house_arrest_get_result(client, out dict);
+            HouseArrestError returnValue;
+            returnValue = HouseArrestNativeMethods.house_arrest_get_result(client, out dict);
+            dict.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -188,7 +222,10 @@ namespace iMobileDevice.HouseArrest
         /// </remarks>
         public virtual AfcError afc_client_new_from_house_arrest_client(HouseArrestClientHandle client, out AfcClientHandle afcClient)
         {
-            return HouseArrestNativeMethods.afc_client_new_from_house_arrest_client(client, out afcClient);
+            AfcError returnValue;
+            returnValue = HouseArrestNativeMethods.afc_client_new_from_house_arrest_client(client, out afcClient);
+            afcClient.Api = this.Parent;
+            return returnValue;
         }
     }
 }

--- a/iMobileDevice/HouseArrest/HouseArrestClientHandle.cs
+++ b/iMobileDevice/HouseArrest/HouseArrestClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.HouseArrest
     public partial class HouseArrestClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected HouseArrestClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.HouseArrest
         protected HouseArrestClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static HouseArrestClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.HouseArrest
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.HouseArrest.house_arrest_client_free(this.handle) == HouseArrestError.Success);
+            return (this.Api.HouseArrest.house_arrest_client_free(this.handle) == HouseArrestError.Success);
         }
         
         public static HouseArrestClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/HouseArrest/IHouseArrestApi.cs
+++ b/iMobileDevice/HouseArrest/IHouseArrestApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.HouseArrest
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="HouseArrest"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the house_arrest service on the specified device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/InstallationProxy/IInstallationProxyApi.cs
+++ b/iMobileDevice/InstallationProxy/IInstallationProxyApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.InstallationProxy
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="InstallationProxy"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the installation_proxy service on the specified device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/InstallationProxy/InstallationProxyApi.cs
+++ b/iMobileDevice/InstallationProxy/InstallationProxyApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.InstallationProxy
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"InstallationProxyApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="InstallationProxy"/>.
+        /// </summary>
+        public InstallationProxyApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the installation_proxy service on the specified device.
         /// </summary>
         /// <param name="device">
@@ -34,7 +59,10 @@ namespace iMobileDevice.InstallationProxy
         /// </returns>
         public virtual InstallationProxyError instproxy_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out InstallationProxyClientHandle client)
         {
-            return InstallationProxyNativeMethods.instproxy_client_new(device, service, out client);
+            InstallationProxyError returnValue;
+            returnValue = InstallationProxyNativeMethods.instproxy_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -58,7 +86,10 @@ namespace iMobileDevice.InstallationProxy
         /// </returns>
         public virtual InstallationProxyError instproxy_client_start_service(iDeviceHandle device, out InstallationProxyClientHandle client, string label)
         {
-            return InstallationProxyNativeMethods.instproxy_client_start_service(device, out client, label);
+            InstallationProxyError returnValue;
+            returnValue = InstallationProxyNativeMethods.instproxy_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -101,7 +132,10 @@ namespace iMobileDevice.InstallationProxy
         /// </returns>
         public virtual InstallationProxyError instproxy_browse(InstallationProxyClientHandle client, PlistHandle clientOptions, out PlistHandle result)
         {
-            return InstallationProxyNativeMethods.instproxy_browse(client, clientOptions, out result);
+            InstallationProxyError returnValue;
+            returnValue = InstallationProxyNativeMethods.instproxy_browse(client, clientOptions, out result);
+            result.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -158,7 +192,10 @@ namespace iMobileDevice.InstallationProxy
         /// </returns>
         public virtual InstallationProxyError instproxy_lookup(InstallationProxyClientHandle client, System.Collections.ObjectModel.ReadOnlyCollection<string> appids, PlistHandle clientOptions, out PlistHandle result)
         {
-            return InstallationProxyNativeMethods.instproxy_lookup(client, appids, clientOptions, out result);
+            InstallationProxyError returnValue;
+            returnValue = InstallationProxyNativeMethods.instproxy_lookup(client, appids, clientOptions, out result);
+            result.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -298,7 +335,10 @@ namespace iMobileDevice.InstallationProxy
         /// </returns>
         public virtual InstallationProxyError instproxy_lookup_archives(InstallationProxyClientHandle client, PlistHandle clientOptions, out PlistHandle result)
         {
-            return InstallationProxyNativeMethods.instproxy_lookup_archives(client, clientOptions, out result);
+            InstallationProxyError returnValue;
+            returnValue = InstallationProxyNativeMethods.instproxy_lookup_archives(client, clientOptions, out result);
+            result.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -439,7 +479,10 @@ namespace iMobileDevice.InstallationProxy
         /// </returns>
         public virtual InstallationProxyError instproxy_check_capabilities_match(InstallationProxyClientHandle client, out string capabilities, PlistHandle clientOptions, out PlistHandle result)
         {
-            return InstallationProxyNativeMethods.instproxy_check_capabilities_match(client, out capabilities, clientOptions, out result);
+            InstallationProxyError returnValue;
+            returnValue = InstallationProxyNativeMethods.instproxy_check_capabilities_match(client, out capabilities, clientOptions, out result);
+            result.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/InstallationProxy/InstallationProxyClientHandle.cs
+++ b/iMobileDevice/InstallationProxy/InstallationProxyClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.InstallationProxy
     public partial class InstallationProxyClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected InstallationProxyClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.InstallationProxy
         protected InstallationProxyClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static InstallationProxyClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.InstallationProxy
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.InstallationProxy.instproxy_client_free(this.handle) == InstallationProxyError.Success);
+            return (this.Api.InstallationProxy.instproxy_client_free(this.handle) == InstallationProxyError.Success);
         }
         
         public static InstallationProxyClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/LibiMobileDevice.cs
+++ b/iMobileDevice/LibiMobileDevice.cs
@@ -94,31 +94,31 @@ namespace iMobileDevice
         
         public LibiMobileDevice()
         {
-            this.usbmuxd = new UsbmuxdApi();
-            this.plist = new PlistApi();
-            this.idevice = new iDeviceApi();
-            this.lockdown = new LockdownApi();
-            this.afc = new AfcApi();
-            this.debugServer = new DebugServerApi();
-            this.diagnosticsRelay = new DiagnosticsRelayApi();
-            this.fileRelay = new FileRelayApi();
-            this.heartBeat = new HeartBeatApi();
-            this.houseArrest = new HouseArrestApi();
-            this.installationProxy = new InstallationProxyApi();
-            this.misagent = new MisagentApi();
-            this.mobileBackup = new MobileBackupApi();
-            this.mobileBackup2 = new MobileBackup2Api();
-            this.mobileSync = new MobileSyncApi();
-            this.mobileImageMounter = new MobileImageMounterApi();
-            this.notificationProxy = new NotificationProxyApi();
-            this.pinvoke = new PinvokeApi();
-            this.propertyListService = new PropertyListServiceApi();
-            this.restore = new RestoreApi();
-            this.springBoardServices = new SpringBoardServicesApi();
-            this.screenshotr = new ScreenshotrApi();
-            this.service = new ServiceApi();
-            this.syslogRelay = new SyslogRelayApi();
-            this.webInspector = new WebInspectorApi();
+            this.usbmuxd = new UsbmuxdApi(this);
+            this.plist = new PlistApi(this);
+            this.idevice = new iDeviceApi(this);
+            this.lockdown = new LockdownApi(this);
+            this.afc = new AfcApi(this);
+            this.debugServer = new DebugServerApi(this);
+            this.diagnosticsRelay = new DiagnosticsRelayApi(this);
+            this.fileRelay = new FileRelayApi(this);
+            this.heartBeat = new HeartBeatApi(this);
+            this.houseArrest = new HouseArrestApi(this);
+            this.installationProxy = new InstallationProxyApi(this);
+            this.misagent = new MisagentApi(this);
+            this.mobileBackup = new MobileBackupApi(this);
+            this.mobileBackup2 = new MobileBackup2Api(this);
+            this.mobileSync = new MobileSyncApi(this);
+            this.mobileImageMounter = new MobileImageMounterApi(this);
+            this.notificationProxy = new NotificationProxyApi(this);
+            this.pinvoke = new PinvokeApi(this);
+            this.propertyListService = new PropertyListServiceApi(this);
+            this.restore = new RestoreApi(this);
+            this.springBoardServices = new SpringBoardServicesApi(this);
+            this.screenshotr = new ScreenshotrApi(this);
+            this.service = new ServiceApi(this);
+            this.syslogRelay = new SyslogRelayApi(this);
+            this.webInspector = new WebInspectorApi(this);
         }
         
         public static ILibiMobileDevice Instance

--- a/iMobileDevice/Lockdown/ILockdownApi.cs
+++ b/iMobileDevice/Lockdown/ILockdownApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.Lockdown
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Lockdown"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Creates a new lockdownd client for the device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/Lockdown/LockdownApi.cs
+++ b/iMobileDevice/Lockdown/LockdownApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.Lockdown
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"LockdownApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Lockdown"/>.
+        /// </summary>
+        public LockdownApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Creates a new lockdownd client for the device.
         /// </summary>
         /// <param name="device">
@@ -39,7 +64,10 @@ namespace iMobileDevice.Lockdown
         /// </remarks>
         public virtual LockdownError lockdownd_client_new(iDeviceHandle device, out LockdownClientHandle client, string label)
         {
-            return LockdownNativeMethods.lockdownd_client_new(device, out client, label);
+            LockdownError returnValue;
+            returnValue = LockdownNativeMethods.lockdownd_client_new(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -68,7 +96,10 @@ namespace iMobileDevice.Lockdown
         /// </remarks>
         public virtual LockdownError lockdownd_client_new_with_handshake(iDeviceHandle device, out LockdownClientHandle client, string label)
         {
-            return LockdownNativeMethods.lockdownd_client_new_with_handshake(device, out client, label);
+            LockdownError returnValue;
+            returnValue = LockdownNativeMethods.lockdownd_client_new_with_handshake(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -124,7 +155,10 @@ namespace iMobileDevice.Lockdown
         /// </returns>
         public virtual LockdownError lockdownd_get_value(LockdownClientHandle client, string domain, string key, out PlistHandle value)
         {
-            return LockdownNativeMethods.lockdownd_get_value(client, domain, key, out value);
+            LockdownError returnValue;
+            returnValue = LockdownNativeMethods.lockdownd_get_value(client, domain, key, out value);
+            value.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -194,7 +228,10 @@ namespace iMobileDevice.Lockdown
         /// </returns>
         public virtual LockdownError lockdownd_start_service(LockdownClientHandle client, string identifier, out LockdownServiceDescriptorHandle service)
         {
-            return LockdownNativeMethods.lockdownd_start_service(client, identifier, out service);
+            LockdownError returnValue;
+            returnValue = LockdownNativeMethods.lockdownd_start_service(client, identifier, out service);
+            service.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -219,7 +256,10 @@ namespace iMobileDevice.Lockdown
         /// </returns>
         public virtual LockdownError lockdownd_start_service_with_escrow_bag(LockdownClientHandle client, string identifier, out LockdownServiceDescriptorHandle service)
         {
-            return LockdownNativeMethods.lockdownd_start_service_with_escrow_bag(client, identifier, out service);
+            LockdownError returnValue;
+            returnValue = LockdownNativeMethods.lockdownd_start_service_with_escrow_bag(client, identifier, out service);
+            service.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -302,7 +342,10 @@ namespace iMobileDevice.Lockdown
         /// </returns>
         public virtual LockdownError lockdownd_receive(LockdownClientHandle client, out PlistHandle plist)
         {
-            return LockdownNativeMethods.lockdownd_receive(client, out plist);
+            LockdownError returnValue;
+            returnValue = LockdownNativeMethods.lockdownd_receive(client, out plist);
+            plist.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -355,7 +398,10 @@ namespace iMobileDevice.Lockdown
         /// </returns>
         public virtual LockdownError lockdownd_pair_with_options(LockdownClientHandle client, LockdownPairRecordHandle pairRecord, PlistHandle options, out PlistHandle response)
         {
-            return LockdownNativeMethods.lockdownd_pair_with_options(client, pairRecord, options, out response);
+            LockdownError returnValue;
+            returnValue = LockdownNativeMethods.lockdownd_pair_with_options(client, pairRecord, options, out response);
+            response.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/Lockdown/LockdownClientHandle.cs
+++ b/iMobileDevice/Lockdown/LockdownClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.Lockdown
     public partial class LockdownClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected LockdownClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.Lockdown
         protected LockdownClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static LockdownClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.Lockdown
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.Lockdown.lockdownd_client_free(this.handle) == LockdownError.Success);
+            return (this.Api.Lockdown.lockdownd_client_free(this.handle) == LockdownError.Success);
         }
         
         public static LockdownClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/Lockdown/LockdownPairRecordHandle.cs
+++ b/iMobileDevice/Lockdown/LockdownPairRecordHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.Lockdown
     public partial class LockdownPairRecordHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected LockdownPairRecordHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.Lockdown
         protected LockdownPairRecordHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static LockdownPairRecordHandle Zero

--- a/iMobileDevice/Lockdown/LockdownServiceDescriptorHandle.cs
+++ b/iMobileDevice/Lockdown/LockdownServiceDescriptorHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.Lockdown
     public partial class LockdownServiceDescriptorHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected LockdownServiceDescriptorHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.Lockdown
         protected LockdownServiceDescriptorHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static LockdownServiceDescriptorHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.Lockdown
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.Lockdown.lockdownd_service_descriptor_free(this.handle) == LockdownError.Success);
+            return (this.Api.Lockdown.lockdownd_service_descriptor_free(this.handle) == LockdownError.Success);
         }
         
         public static LockdownServiceDescriptorHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/Misagent/IMisagentApi.cs
+++ b/iMobileDevice/Misagent/IMisagentApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.Misagent
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Misagent"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the misagent service on the specified device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/Misagent/MisagentApi.cs
+++ b/iMobileDevice/Misagent/MisagentApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.Misagent
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"MisagentApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Misagent"/>.
+        /// </summary>
+        public MisagentApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the misagent service on the specified device.
         /// </summary>
         /// <param name="device">
@@ -34,7 +59,10 @@ namespace iMobileDevice.Misagent
         /// </returns>
         public virtual MisagentError misagent_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out MisagentClientHandle client)
         {
-            return MisagentNativeMethods.misagent_client_new(device, service, out client);
+            MisagentError returnValue;
+            returnValue = MisagentNativeMethods.misagent_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -58,7 +86,10 @@ namespace iMobileDevice.Misagent
         /// </returns>
         public virtual MisagentError misagent_client_start_service(iDeviceHandle device, out MisagentClientHandle client, string label)
         {
-            return MisagentNativeMethods.misagent_client_start_service(device, out client, label);
+            MisagentError returnValue;
+            returnValue = MisagentNativeMethods.misagent_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -117,7 +148,10 @@ namespace iMobileDevice.Misagent
         /// </remarks>
         public virtual MisagentError misagent_copy(MisagentClientHandle client, out PlistHandle profiles)
         {
-            return MisagentNativeMethods.misagent_copy(client, out profiles);
+            MisagentError returnValue;
+            returnValue = MisagentNativeMethods.misagent_copy(client, out profiles);
+            profiles.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/Misagent/MisagentClientHandle.cs
+++ b/iMobileDevice/Misagent/MisagentClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.Misagent
     public partial class MisagentClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected MisagentClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.Misagent
         protected MisagentClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static MisagentClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.Misagent
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.Misagent.misagent_client_free(this.handle) == MisagentError.Success);
+            return (this.Api.Misagent.misagent_client_free(this.handle) == MisagentError.Success);
         }
         
         public static MisagentClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/MobileBackup/IMobileBackupApi.cs
+++ b/iMobileDevice/MobileBackup/IMobileBackupApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.MobileBackup
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="MobileBackup"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the mobilebackup service on the specified device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/MobileBackup/MobileBackupApi.cs
+++ b/iMobileDevice/MobileBackup/MobileBackupApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.MobileBackup
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"MobileBackupApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="MobileBackup"/>.
+        /// </summary>
+        public MobileBackupApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the mobilebackup service on the specified device.
         /// </summary>
         /// <param name="device">
@@ -35,7 +60,10 @@ namespace iMobileDevice.MobileBackup
         /// </returns>
         public virtual MobileBackupError mobilebackup_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out MobileBackupClientHandle client)
         {
-            return MobileBackupNativeMethods.mobilebackup_client_new(device, service, out client);
+            MobileBackupError returnValue;
+            returnValue = MobileBackupNativeMethods.mobilebackup_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -59,7 +87,10 @@ namespace iMobileDevice.MobileBackup
         /// </returns>
         public virtual MobileBackupError mobilebackup_client_start_service(iDeviceHandle device, out MobileBackupClientHandle client, string label)
         {
-            return MobileBackupNativeMethods.mobilebackup_client_start_service(device, out client, label);
+            MobileBackupError returnValue;
+            returnValue = MobileBackupNativeMethods.mobilebackup_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -92,7 +123,10 @@ namespace iMobileDevice.MobileBackup
         /// </returns>
         public virtual MobileBackupError mobilebackup_receive(MobileBackupClientHandle client, out PlistHandle plist)
         {
-            return MobileBackupNativeMethods.mobilebackup_receive(client, out plist);
+            MobileBackupError returnValue;
+            returnValue = MobileBackupNativeMethods.mobilebackup_receive(client, out plist);
+            plist.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -220,7 +254,10 @@ namespace iMobileDevice.MobileBackup
         /// </returns>
         public virtual MobileBackupError mobilebackup_receive_restore_file_received(MobileBackupClientHandle client, out PlistHandle result)
         {
-            return MobileBackupNativeMethods.mobilebackup_receive_restore_file_received(client, out result);
+            MobileBackupError returnValue;
+            returnValue = MobileBackupNativeMethods.mobilebackup_receive_restore_file_received(client, out result);
+            result.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -247,7 +284,10 @@ namespace iMobileDevice.MobileBackup
         /// </returns>
         public virtual MobileBackupError mobilebackup_receive_restore_application_received(MobileBackupClientHandle client, out PlistHandle result)
         {
-            return MobileBackupNativeMethods.mobilebackup_receive_restore_application_received(client, out result);
+            MobileBackupError returnValue;
+            returnValue = MobileBackupNativeMethods.mobilebackup_receive_restore_application_received(client, out result);
+            result.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/MobileBackup/MobileBackupClientHandle.cs
+++ b/iMobileDevice/MobileBackup/MobileBackupClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.MobileBackup
     public partial class MobileBackupClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected MobileBackupClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.MobileBackup
         protected MobileBackupClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static MobileBackupClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.MobileBackup
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.MobileBackup.mobilebackup_client_free(this.handle) == MobileBackupError.Success);
+            return (this.Api.MobileBackup.mobilebackup_client_free(this.handle) == MobileBackupError.Success);
         }
         
         public static MobileBackupClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/MobileBackup2/IMobileBackup2Api.cs
+++ b/iMobileDevice/MobileBackup2/IMobileBackup2Api.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.MobileBackup2
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="MobileBackup2"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the mobilebackup2 service on the specified device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/MobileBackup2/MobileBackup2Api.cs
+++ b/iMobileDevice/MobileBackup2/MobileBackup2Api.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.MobileBackup2
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"MobileBackup2Api"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="MobileBackup2"/>.
+        /// </summary>
+        public MobileBackup2Api(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the mobilebackup2 service on the specified device.
         /// </summary>
         /// <param name="device">
@@ -35,7 +60,10 @@ namespace iMobileDevice.MobileBackup2
         /// </returns>
         public virtual MobileBackup2Error mobilebackup2_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out MobileBackup2ClientHandle client)
         {
-            return MobileBackup2NativeMethods.mobilebackup2_client_new(device, service, out client);
+            MobileBackup2Error returnValue;
+            returnValue = MobileBackup2NativeMethods.mobilebackup2_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -59,7 +87,10 @@ namespace iMobileDevice.MobileBackup2
         /// </returns>
         public virtual MobileBackup2Error mobilebackup2_client_start_service(iDeviceHandle device, out MobileBackup2ClientHandle client, string label)
         {
-            return MobileBackup2NativeMethods.mobilebackup2_client_start_service(device, out client, label);
+            MobileBackup2Error returnValue;
+            returnValue = MobileBackup2NativeMethods.mobilebackup2_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -126,7 +157,10 @@ namespace iMobileDevice.MobileBackup2
         /// </returns>
         public virtual MobileBackup2Error mobilebackup2_receive_message(MobileBackup2ClientHandle client, out PlistHandle msgPlist, out string dlmessage)
         {
-            return MobileBackup2NativeMethods.mobilebackup2_receive_message(client, out msgPlist, out dlmessage);
+            MobileBackup2Error returnValue;
+            returnValue = MobileBackup2NativeMethods.mobilebackup2_receive_message(client, out msgPlist, out dlmessage);
+            msgPlist.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/MobileBackup2/MobileBackup2ClientHandle.cs
+++ b/iMobileDevice/MobileBackup2/MobileBackup2ClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.MobileBackup2
     public partial class MobileBackup2ClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected MobileBackup2ClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.MobileBackup2
         protected MobileBackup2ClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static MobileBackup2ClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.MobileBackup2
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.MobileBackup2.mobilebackup2_client_free(this.handle) == MobileBackup2Error.Success);
+            return (this.Api.MobileBackup2.mobilebackup2_client_free(this.handle) == MobileBackup2Error.Success);
         }
         
         public static MobileBackup2ClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/MobileImageMounter/IMobileImageMounterApi.cs
+++ b/iMobileDevice/MobileImageMounter/IMobileImageMounterApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.MobileImageMounter
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="MobileImageMounter"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the mobile_image_mounter service on the specified device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/MobileImageMounter/MobileImageMounterApi.cs
+++ b/iMobileDevice/MobileImageMounter/MobileImageMounterApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.MobileImageMounter
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"MobileImageMounterApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="MobileImageMounter"/>.
+        /// </summary>
+        public MobileImageMounterApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the mobile_image_mounter service on the specified device.
         /// </summary>
         /// <param name="device">
@@ -36,7 +61,10 @@ namespace iMobileDevice.MobileImageMounter
         /// </returns>
         public virtual MobileImageMounterError mobile_image_mounter_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out MobileImageMounterClientHandle client)
         {
-            return MobileImageMounterNativeMethods.mobile_image_mounter_new(device, service, out client);
+            MobileImageMounterError returnValue;
+            returnValue = MobileImageMounterNativeMethods.mobile_image_mounter_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -60,7 +88,10 @@ namespace iMobileDevice.MobileImageMounter
         /// </returns>
         public virtual MobileImageMounterError mobile_image_mounter_start_service(iDeviceHandle device, out MobileImageMounterClientHandle client, string label)
         {
-            return MobileImageMounterNativeMethods.mobile_image_mounter_start_service(device, out client, label);
+            MobileImageMounterError returnValue;
+            returnValue = MobileImageMounterNativeMethods.mobile_image_mounter_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -101,7 +132,10 @@ namespace iMobileDevice.MobileImageMounter
         /// </remarks>
         public virtual MobileImageMounterError mobile_image_mounter_lookup_image(MobileImageMounterClientHandle client, string imageType, out PlistHandle result)
         {
-            return MobileImageMounterNativeMethods.mobile_image_mounter_lookup_image(client, imageType, out result);
+            MobileImageMounterError returnValue;
+            returnValue = MobileImageMounterNativeMethods.mobile_image_mounter_lookup_image(client, imageType, out result);
+            result.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -176,7 +210,10 @@ namespace iMobileDevice.MobileImageMounter
         /// </remarks>
         public virtual MobileImageMounterError mobile_image_mounter_mount_image(MobileImageMounterClientHandle client, string imagePath, byte[] signature, ushort signatureSize, string imageType, out PlistHandle result)
         {
-            return MobileImageMounterNativeMethods.mobile_image_mounter_mount_image(client, imagePath, signature, signatureSize, imageType, out result);
+            MobileImageMounterError returnValue;
+            returnValue = MobileImageMounterNativeMethods.mobile_image_mounter_mount_image(client, imagePath, signature, signatureSize, imageType, out result);
+            result.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/MobileImageMounter/MobileImageMounterClientHandle.cs
+++ b/iMobileDevice/MobileImageMounter/MobileImageMounterClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.MobileImageMounter
     public partial class MobileImageMounterClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected MobileImageMounterClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.MobileImageMounter
         protected MobileImageMounterClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static MobileImageMounterClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.MobileImageMounter
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.MobileImageMounter.mobile_image_mounter_free(this.handle) == MobileImageMounterError.Success);
+            return (this.Api.MobileImageMounter.mobile_image_mounter_free(this.handle) == MobileImageMounterError.Success);
         }
         
         public static MobileImageMounterClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/MobileSync/IMobileSyncApi.cs
+++ b/iMobileDevice/MobileSync/IMobileSyncApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.MobileSync
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="MobileSync"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the mobilesync service on the specified device.
         /// MOBILESYNC_E_SUCCESS on success
         /// MOBILESYNC_E_INVALID_ARG if one or more parameters are invalid

--- a/iMobileDevice/MobileSync/MobileSyncAnchorsHandle.cs
+++ b/iMobileDevice/MobileSync/MobileSyncAnchorsHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.MobileSync
     public partial class MobileSyncAnchorsHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected MobileSyncAnchorsHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.MobileSync
         protected MobileSyncAnchorsHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static MobileSyncAnchorsHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.MobileSync
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.MobileSync.mobilesync_anchors_free(this.handle) == MobileSyncError.Success);
+            return (this.Api.MobileSync.mobilesync_anchors_free(this.handle) == MobileSyncError.Success);
         }
         
         public static MobileSyncAnchorsHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/MobileSync/MobileSyncApi.cs
+++ b/iMobileDevice/MobileSync/MobileSyncApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.MobileSync
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"MobileSyncApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="MobileSync"/>.
+        /// </summary>
+        public MobileSyncApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the mobilesync service on the specified device.
         /// MOBILESYNC_E_SUCCESS on success
         /// MOBILESYNC_E_INVALID_ARG if one or more parameters are invalid
@@ -34,7 +59,10 @@ namespace iMobileDevice.MobileSync
         /// </param>
         public virtual MobileSyncError mobilesync_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out MobileSyncClientHandle client)
         {
-            return MobileSyncNativeMethods.mobilesync_client_new(device, service, out client);
+            MobileSyncError returnValue;
+            returnValue = MobileSyncNativeMethods.mobilesync_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -58,7 +86,10 @@ namespace iMobileDevice.MobileSync
         /// </returns>
         public virtual MobileSyncError mobilesync_client_start_service(iDeviceHandle device, out MobileSyncClientHandle client, string label)
         {
-            return MobileSyncNativeMethods.mobilesync_client_start_service(device, out client, label);
+            MobileSyncError returnValue;
+            returnValue = MobileSyncNativeMethods.mobilesync_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -90,7 +121,10 @@ namespace iMobileDevice.MobileSync
         /// </returns>
         public virtual MobileSyncError mobilesync_receive(MobileSyncClientHandle client, out PlistHandle plist)
         {
-            return MobileSyncNativeMethods.mobilesync_receive(client, out plist);
+            MobileSyncError returnValue;
+            returnValue = MobileSyncNativeMethods.mobilesync_receive(client, out plist);
+            plist.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -251,7 +285,11 @@ namespace iMobileDevice.MobileSync
         /// </param>
         public virtual MobileSyncError mobilesync_receive_changes(MobileSyncClientHandle client, out PlistHandle entities, ref char isLastRecord, out PlistHandle actions)
         {
-            return MobileSyncNativeMethods.mobilesync_receive_changes(client, out entities, ref isLastRecord, out actions);
+            MobileSyncError returnValue;
+            returnValue = MobileSyncNativeMethods.mobilesync_receive_changes(client, out entities, ref isLastRecord, out actions);
+            entities.Api = this.Parent;
+            actions.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -333,7 +371,10 @@ namespace iMobileDevice.MobileSync
         /// </param>
         public virtual MobileSyncError mobilesync_remap_identifiers(MobileSyncClientHandle client, out PlistHandle mapping)
         {
-            return MobileSyncNativeMethods.mobilesync_remap_identifiers(client, out mapping);
+            MobileSyncError returnValue;
+            returnValue = MobileSyncNativeMethods.mobilesync_remap_identifiers(client, out mapping);
+            mapping.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -353,7 +394,10 @@ namespace iMobileDevice.MobileSync
         /// </param>
         public virtual MobileSyncError mobilesync_anchors_new(string deviceAnchor, string computerAnchor, out MobileSyncAnchorsHandle anchor)
         {
-            return MobileSyncNativeMethods.mobilesync_anchors_new(deviceAnchor, computerAnchor, out anchor);
+            MobileSyncError returnValue;
+            returnValue = MobileSyncNativeMethods.mobilesync_anchors_new(deviceAnchor, computerAnchor, out anchor);
+            anchor.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/MobileSync/MobileSyncClientHandle.cs
+++ b/iMobileDevice/MobileSync/MobileSyncClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.MobileSync
     public partial class MobileSyncClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected MobileSyncClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.MobileSync
         protected MobileSyncClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static MobileSyncClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.MobileSync
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.MobileSync.mobilesync_client_free(this.handle) == MobileSyncError.Success);
+            return (this.Api.MobileSync.mobilesync_client_free(this.handle) == MobileSyncError.Success);
         }
         
         public static MobileSyncClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/NotificationProxy/INotificationProxyApi.cs
+++ b/iMobileDevice/NotificationProxy/INotificationProxyApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.NotificationProxy
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="NotificationProxy"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the notification_proxy on the specified device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/NotificationProxy/NotificationProxyApi.cs
+++ b/iMobileDevice/NotificationProxy/NotificationProxyApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.NotificationProxy
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"NotificationProxyApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="NotificationProxy"/>.
+        /// </summary>
+        public NotificationProxyApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the notification_proxy on the specified device.
         /// </summary>
         /// <param name="device">
@@ -35,7 +60,10 @@ namespace iMobileDevice.NotificationProxy
         /// </returns>
         public virtual NotificationProxyError np_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out NotificationProxyClientHandle client)
         {
-            return NotificationProxyNativeMethods.np_client_new(device, service, out client);
+            NotificationProxyError returnValue;
+            returnValue = NotificationProxyNativeMethods.np_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -59,7 +87,10 @@ namespace iMobileDevice.NotificationProxy
         /// </returns>
         public virtual NotificationProxyError np_client_start_service(iDeviceHandle device, out NotificationProxyClientHandle client, string label)
         {
-            return NotificationProxyNativeMethods.np_client_start_service(device, out client, label);
+            NotificationProxyError returnValue;
+            returnValue = NotificationProxyNativeMethods.np_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/NotificationProxy/NotificationProxyClientHandle.cs
+++ b/iMobileDevice/NotificationProxy/NotificationProxyClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.NotificationProxy
     public partial class NotificationProxyClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected NotificationProxyClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.NotificationProxy
         protected NotificationProxyClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static NotificationProxyClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.NotificationProxy
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.NotificationProxy.np_client_free(this.handle) == NotificationProxyError.Success);
+            return (this.Api.NotificationProxy.np_client_free(this.handle) == NotificationProxyError.Success);
         }
         
         public static NotificationProxyClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/Pinvoke/IPinvokeApi.cs
+++ b/iMobileDevice/Pinvoke/IPinvokeApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.Pinvoke
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Pinvoke"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Frees a string that was previously allocated by libimobiledevice.
         /// </summary>
         /// <param name="string">

--- a/iMobileDevice/Pinvoke/PinvokeApi.cs
+++ b/iMobileDevice/Pinvoke/PinvokeApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.Pinvoke
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"PinvokeApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Pinvoke"/>.
+        /// </summary>
+        public PinvokeApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Frees a string that was previously allocated by libimobiledevice.
         /// </summary>
         /// <param name="string">

--- a/iMobileDevice/Plist/IPlistApi.cs
+++ b/iMobileDevice/Plist/IPlistApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.Plist
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Plist"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Frees memory used globally by listplist, in
         /// particular the libxml parser
         /// </summary>

--- a/iMobileDevice/Plist/PlistApi.cs
+++ b/iMobileDevice/Plist/PlistApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.Plist
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"PlistApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Plist"/>.
+        /// </summary>
+        public PlistApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Frees memory used globally by listplist, in
         /// particular the libxml parser
         /// </summary>

--- a/iMobileDevice/Plist/PlistDictIterHandle.cs
+++ b/iMobileDevice/Plist/PlistDictIterHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.Plist
     public partial class PlistDictIterHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected PlistDictIterHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.Plist
         protected PlistDictIterHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static PlistDictIterHandle Zero

--- a/iMobileDevice/Plist/PlistHandle.cs
+++ b/iMobileDevice/Plist/PlistHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.Plist
     public partial class PlistHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected PlistHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.Plist
         protected PlistHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static PlistHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.Plist
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            LibiMobileDevice.Instance.Plist.plist_free(this.handle);
+            this.Api.Plist.plist_free(this.handle);
             return true;
         }
         

--- a/iMobileDevice/PropertyListService/IPropertyListServiceApi.cs
+++ b/iMobileDevice/PropertyListService/IPropertyListServiceApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.PropertyListService
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="PropertyListService"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Creates a new property list service for the specified port.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/PropertyListService/PropertyListServiceApi.cs
+++ b/iMobileDevice/PropertyListService/PropertyListServiceApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.PropertyListService
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"PropertyListServiceApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="PropertyListService"/>.
+        /// </summary>
+        public PropertyListServiceApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Creates a new property list service for the specified port.
         /// </summary>
         /// <param name="device">
@@ -35,7 +60,10 @@ namespace iMobileDevice.PropertyListService
         /// </returns>
         public virtual PropertyListServiceError property_list_service_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out PropertyListServiceClientHandle client)
         {
-            return PropertyListServiceNativeMethods.property_list_service_client_new(device, service, out client);
+            PropertyListServiceError returnValue;
+            returnValue = PropertyListServiceNativeMethods.property_list_service_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -119,7 +147,10 @@ namespace iMobileDevice.PropertyListService
         /// </returns>
         public virtual PropertyListServiceError property_list_service_receive_plist_with_timeout(PropertyListServiceClientHandle client, out PlistHandle plist, uint timeout)
         {
-            return PropertyListServiceNativeMethods.property_list_service_receive_plist_with_timeout(client, out plist, timeout);
+            PropertyListServiceError returnValue;
+            returnValue = PropertyListServiceNativeMethods.property_list_service_receive_plist_with_timeout(client, out plist, timeout);
+            plist.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -145,7 +176,10 @@ namespace iMobileDevice.PropertyListService
         /// </returns>
         public virtual PropertyListServiceError property_list_service_receive_plist(PropertyListServiceClientHandle client, out PlistHandle plist)
         {
-            return PropertyListServiceNativeMethods.property_list_service_receive_plist(client, out plist);
+            PropertyListServiceError returnValue;
+            returnValue = PropertyListServiceNativeMethods.property_list_service_receive_plist(client, out plist);
+            plist.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/PropertyListService/PropertyListServiceClientHandle.cs
+++ b/iMobileDevice/PropertyListService/PropertyListServiceClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.PropertyListService
     public partial class PropertyListServiceClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected PropertyListServiceClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.PropertyListService
         protected PropertyListServiceClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static PropertyListServiceClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.PropertyListService
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.PropertyListService.property_list_service_client_free(this.handle) == PropertyListServiceError.Success);
+            return (this.Api.PropertyListService.property_list_service_client_free(this.handle) == PropertyListServiceError.Success);
         }
         
         public static PropertyListServiceClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/Restore/IRestoreApi.cs
+++ b/iMobileDevice/Restore/IRestoreApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.Restore
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Restore"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Creates a new restored client for the device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/Restore/RestoreApi.cs
+++ b/iMobileDevice/Restore/RestoreApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.Restore
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"RestoreApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Restore"/>.
+        /// </summary>
+        public RestoreApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Creates a new restored client for the device.
         /// </summary>
         /// <param name="device">
@@ -32,7 +57,10 @@ namespace iMobileDevice.Restore
         /// </returns>
         public virtual RestoreError restored_client_new(iDeviceHandle device, out RestoreClientHandle client, string label)
         {
-            return RestoreNativeMethods.restored_client_new(device, out client, label);
+            RestoreError returnValue;
+            returnValue = RestoreNativeMethods.restored_client_new(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -88,7 +116,10 @@ namespace iMobileDevice.Restore
         /// </returns>
         public virtual RestoreError restored_query_value(RestoreClientHandle client, string key, out PlistHandle value)
         {
-            return RestoreNativeMethods.restored_query_value(client, key, out value);
+            RestoreError returnValue;
+            returnValue = RestoreNativeMethods.restored_query_value(client, key, out value);
+            value.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -108,7 +139,10 @@ namespace iMobileDevice.Restore
         /// </returns>
         public virtual RestoreError restored_get_value(RestoreClientHandle client, string key, out PlistHandle value)
         {
-            return RestoreNativeMethods.restored_get_value(client, key, out value);
+            RestoreError returnValue;
+            returnValue = RestoreNativeMethods.restored_get_value(client, key, out value);
+            value.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -148,7 +182,10 @@ namespace iMobileDevice.Restore
         /// </returns>
         public virtual RestoreError restored_receive(RestoreClientHandle client, out PlistHandle plist)
         {
-            return RestoreNativeMethods.restored_receive(client, out plist);
+            RestoreError returnValue;
+            returnValue = RestoreNativeMethods.restored_receive(client, out plist);
+            plist.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/Restore/RestoreClientHandle.cs
+++ b/iMobileDevice/Restore/RestoreClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.Restore
     public partial class RestoreClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected RestoreClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.Restore
         protected RestoreClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static RestoreClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.Restore
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.Restore.restored_client_free(this.handle) == RestoreError.Success);
+            return (this.Api.Restore.restored_client_free(this.handle) == RestoreError.Success);
         }
         
         public static RestoreClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/Screenshotr/IScreenshotrApi.cs
+++ b/iMobileDevice/Screenshotr/IScreenshotrApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.Screenshotr
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Screenshotr"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the screenshotr service on the specified device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/Screenshotr/ScreenshotrApi.cs
+++ b/iMobileDevice/Screenshotr/ScreenshotrApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.Screenshotr
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"ScreenshotrApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Screenshotr"/>.
+        /// </summary>
+        public ScreenshotrApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the screenshotr service on the specified device.
         /// </summary>
         /// <param name="device">
@@ -39,7 +64,10 @@ namespace iMobileDevice.Screenshotr
         /// </remarks>
         public virtual ScreenshotrError screenshotr_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out ScreenshotrClientHandle client)
         {
-            return ScreenshotrNativeMethods.screenshotr_client_new(device, service, out client);
+            ScreenshotrError returnValue;
+            returnValue = ScreenshotrNativeMethods.screenshotr_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -63,7 +91,10 @@ namespace iMobileDevice.Screenshotr
         /// </returns>
         public virtual ScreenshotrError screenshotr_client_start_service(iDeviceHandle device, out ScreenshotrClientHandle client, string label)
         {
-            return ScreenshotrNativeMethods.screenshotr_client_start_service(device, out client, label);
+            ScreenshotrError returnValue;
+            returnValue = ScreenshotrNativeMethods.screenshotr_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/Screenshotr/ScreenshotrClientHandle.cs
+++ b/iMobileDevice/Screenshotr/ScreenshotrClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.Screenshotr
     public partial class ScreenshotrClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected ScreenshotrClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.Screenshotr
         protected ScreenshotrClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static ScreenshotrClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.Screenshotr
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.Screenshotr.screenshotr_client_free(this.handle) == ScreenshotrError.Success);
+            return (this.Api.Screenshotr.screenshotr_client_free(this.handle) == ScreenshotrError.Success);
         }
         
         public static ScreenshotrClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/Service/IServiceApi.cs
+++ b/iMobileDevice/Service/IServiceApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.Service
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Service"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Creates a new service for the specified service descriptor.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/Service/ServiceApi.cs
+++ b/iMobileDevice/Service/ServiceApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.Service
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"ServiceApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Service"/>.
+        /// </summary>
+        public ServiceApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Creates a new service for the specified service descriptor.
         /// </summary>
         /// <param name="device">
@@ -35,7 +60,10 @@ namespace iMobileDevice.Service
         /// </returns>
         public virtual ServiceError service_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out ServiceClientHandle client)
         {
-            return ServiceNativeMethods.service_client_new(device, service, out client);
+            ServiceError returnValue;
+            returnValue = ServiceNativeMethods.service_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/Service/ServiceClientHandle.cs
+++ b/iMobileDevice/Service/ServiceClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.Service
     public partial class ServiceClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected ServiceClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.Service
         protected ServiceClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static ServiceClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.Service
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.Service.service_client_free(this.handle) == ServiceError.Success);
+            return (this.Api.Service.service_client_free(this.handle) == ServiceError.Success);
         }
         
         public static ServiceClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/SpringBoardServices/ISpringBoardServicesApi.cs
+++ b/iMobileDevice/SpringBoardServices/ISpringBoardServicesApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.SpringBoardServices
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="SpringBoardServices"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the springboardservices service on the specified device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/SpringBoardServices/SpringBoardServicesApi.cs
+++ b/iMobileDevice/SpringBoardServices/SpringBoardServicesApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.SpringBoardServices
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"SpringBoardServicesApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="SpringBoardServices"/>.
+        /// </summary>
+        public SpringBoardServicesApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the springboardservices service on the specified device.
         /// </summary>
         /// <param name="device">
@@ -34,7 +59,10 @@ namespace iMobileDevice.SpringBoardServices
         /// </returns>
         public virtual SpringBoardServicesError sbservices_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out SpringBoardServicesClientHandle client)
         {
-            return SpringBoardServicesNativeMethods.sbservices_client_new(device, service, out client);
+            SpringBoardServicesError returnValue;
+            returnValue = SpringBoardServicesNativeMethods.sbservices_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -58,7 +86,10 @@ namespace iMobileDevice.SpringBoardServices
         /// </returns>
         public virtual SpringBoardServicesError sbservices_client_start_service(iDeviceHandle device, out SpringBoardServicesClientHandle client, string label)
         {
-            return SpringBoardServicesNativeMethods.sbservices_client_start_service(device, out client, label);
+            SpringBoardServicesError returnValue;
+            returnValue = SpringBoardServicesNativeMethods.sbservices_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -99,7 +130,10 @@ namespace iMobileDevice.SpringBoardServices
         /// </returns>
         public virtual SpringBoardServicesError sbservices_get_icon_state(SpringBoardServicesClientHandle client, out PlistHandle state, string formatVersion)
         {
-            return SpringBoardServicesNativeMethods.sbservices_get_icon_state(client, out state, formatVersion);
+            SpringBoardServicesError returnValue;
+            returnValue = SpringBoardServicesNativeMethods.sbservices_get_icon_state(client, out state, formatVersion);
+            state.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/SpringBoardServices/SpringBoardServicesClientHandle.cs
+++ b/iMobileDevice/SpringBoardServices/SpringBoardServicesClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.SpringBoardServices
     public partial class SpringBoardServicesClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected SpringBoardServicesClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.SpringBoardServices
         protected SpringBoardServicesClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static SpringBoardServicesClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.SpringBoardServices
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.SpringBoardServices.sbservices_client_free(this.handle) == SpringBoardServicesError.Success);
+            return (this.Api.SpringBoardServices.sbservices_client_free(this.handle) == SpringBoardServicesError.Success);
         }
         
         public static SpringBoardServicesClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/SyslogRelay/ISyslogRelayApi.cs
+++ b/iMobileDevice/SyslogRelay/ISyslogRelayApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.SyslogRelay
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="SyslogRelay"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the syslog_relay service on the specified device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/SyslogRelay/SyslogRelayApi.cs
+++ b/iMobileDevice/SyslogRelay/SyslogRelayApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.SyslogRelay
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"SyslogRelayApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="SyslogRelay"/>.
+        /// </summary>
+        public SyslogRelayApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the syslog_relay service on the specified device.
         /// </summary>
         /// <param name="device">
@@ -35,7 +60,10 @@ namespace iMobileDevice.SyslogRelay
         /// </returns>
         public virtual SyslogRelayError syslog_relay_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out SyslogRelayClientHandle client)
         {
-            return SyslogRelayNativeMethods.syslog_relay_client_new(device, service, out client);
+            SyslogRelayError returnValue;
+            returnValue = SyslogRelayNativeMethods.syslog_relay_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -59,7 +87,10 @@ namespace iMobileDevice.SyslogRelay
         /// </returns>
         public virtual SyslogRelayError syslog_relay_client_start_service(iDeviceHandle device, out SyslogRelayClientHandle client, string label)
         {
-            return SyslogRelayNativeMethods.syslog_relay_client_start_service(device, out client, label);
+            SyslogRelayError returnValue;
+            returnValue = SyslogRelayNativeMethods.syslog_relay_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/SyslogRelay/SyslogRelayClientHandle.cs
+++ b/iMobileDevice/SyslogRelay/SyslogRelayClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.SyslogRelay
     public partial class SyslogRelayClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected SyslogRelayClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.SyslogRelay
         protected SyslogRelayClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static SyslogRelayClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.SyslogRelay
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.SyslogRelay.syslog_relay_client_free(this.handle) == SyslogRelayError.Success);
+            return (this.Api.SyslogRelay.syslog_relay_client_free(this.handle) == SyslogRelayError.Success);
         }
         
         public static SyslogRelayClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/Usbmuxd/IUsbmuxdApi.cs
+++ b/iMobileDevice/Usbmuxd/IUsbmuxdApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.Usbmuxd
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Usbmuxd"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Subscribe a callback function so that applications get to know about
         /// device add/remove events.
         /// </summary>

--- a/iMobileDevice/Usbmuxd/UsbmuxdApi.cs
+++ b/iMobileDevice/Usbmuxd/UsbmuxdApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.Usbmuxd
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"UsbmuxdApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="Usbmuxd"/>.
+        /// </summary>
+        public UsbmuxdApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Subscribe a callback function so that applications get to know about
         /// device add/remove events.
         /// </summary>

--- a/iMobileDevice/WebInspector/IWebInspectorApi.cs
+++ b/iMobileDevice/WebInspector/IWebInspectorApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.WebInspector
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="WebInspector"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Connects to the webinspector service on the specified device.
         /// </summary>
         /// <param name="device">

--- a/iMobileDevice/WebInspector/WebInspectorApi.cs
+++ b/iMobileDevice/WebInspector/WebInspectorApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.WebInspector
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"WebInspectorApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="WebInspector"/>.
+        /// </summary>
+        public WebInspectorApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Connects to the webinspector service on the specified device.
         /// </summary>
         /// <param name="device">
@@ -35,7 +60,10 @@ namespace iMobileDevice.WebInspector
         /// </returns>
         public virtual WebInspectorError webinspector_client_new(iDeviceHandle device, LockdownServiceDescriptorHandle service, out WebInspectorClientHandle client)
         {
-            return WebInspectorNativeMethods.webinspector_client_new(device, service, out client);
+            WebInspectorError returnValue;
+            returnValue = WebInspectorNativeMethods.webinspector_client_new(device, service, out client);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -59,7 +87,10 @@ namespace iMobileDevice.WebInspector
         /// </returns>
         public virtual WebInspectorError webinspector_client_start_service(iDeviceHandle device, out WebInspectorClientHandle client, string label)
         {
-            return WebInspectorNativeMethods.webinspector_client_start_service(device, out client, label);
+            WebInspectorError returnValue;
+            returnValue = WebInspectorNativeMethods.webinspector_client_start_service(device, out client, label);
+            client.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -111,7 +142,10 @@ namespace iMobileDevice.WebInspector
         /// </returns>
         public virtual WebInspectorError webinspector_receive(WebInspectorClientHandle client, out PlistHandle plist)
         {
-            return WebInspectorNativeMethods.webinspector_receive(client, out plist);
+            WebInspectorError returnValue;
+            returnValue = WebInspectorNativeMethods.webinspector_receive(client, out plist);
+            plist.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -137,7 +171,10 @@ namespace iMobileDevice.WebInspector
         /// </returns>
         public virtual WebInspectorError webinspector_receive_with_timeout(WebInspectorClientHandle client, out PlistHandle plist, uint timeoutMs)
         {
-            return WebInspectorNativeMethods.webinspector_receive_with_timeout(client, out plist, timeoutMs);
+            WebInspectorError returnValue;
+            returnValue = WebInspectorNativeMethods.webinspector_receive_with_timeout(client, out plist, timeoutMs);
+            plist.Api = this.Parent;
+            return returnValue;
         }
     }
 }

--- a/iMobileDevice/WebInspector/WebInspectorClientHandle.cs
+++ b/iMobileDevice/WebInspector/WebInspectorClientHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.WebInspector
     public partial class WebInspectorClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected WebInspectorClientHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.WebInspector
         protected WebInspectorClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static WebInspectorClientHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.WebInspector
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.WebInspector.webinspector_client_free(this.handle) == WebInspectorError.Success);
+            return (this.Api.WebInspector.webinspector_client_free(this.handle) == WebInspectorError.Success);
         }
         
         public static WebInspectorClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/iDevice/IiDeviceApi.cs
+++ b/iMobileDevice/iDevice/IiDeviceApi.cs
@@ -16,6 +16,14 @@ namespace iMobileDevice.iDevice
     {
         
         /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="iDevice"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        /// <summary>
         /// Sets the callback to invoke when writing out debug messages. If this callback is set, messages
         /// will be written to this callback instead of the standard output.
         /// </summary>

--- a/iMobileDevice/iDevice/iDeviceApi.cs
+++ b/iMobileDevice/iDevice/iDeviceApi.cs
@@ -16,6 +16,31 @@ namespace iMobileDevice.iDevice
     {
         
         /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"iDeviceApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="iDevice"/>.
+        /// </summary>
+        public iDeviceApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        /// <summary>
         /// Sets the callback to invoke when writing out debug messages. If this callback is set, messages
         /// will be written to this callback instead of the standard output.
         /// </summary>
@@ -123,7 +148,10 @@ namespace iMobileDevice.iDevice
         /// </remarks>
         public virtual iDeviceError idevice_new(out iDeviceHandle device, string udid)
         {
-            return iDeviceNativeMethods.idevice_new(out device, udid);
+            iDeviceError returnValue;
+            returnValue = iDeviceNativeMethods.idevice_new(out device, udid);
+            device.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>
@@ -157,7 +185,10 @@ namespace iMobileDevice.iDevice
         /// </returns>
         public virtual iDeviceError idevice_connect(iDeviceHandle device, ushort port, out iDeviceConnectionHandle connection)
         {
-            return iDeviceNativeMethods.idevice_connect(device, port, out connection);
+            iDeviceError returnValue;
+            returnValue = iDeviceNativeMethods.idevice_connect(device, port, out connection);
+            connection.Api = this.Parent;
+            return returnValue;
         }
         
         /// <summary>

--- a/iMobileDevice/iDevice/iDeviceConnectionHandle.cs
+++ b/iMobileDevice/iDevice/iDeviceConnectionHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.iDevice
     public partial class iDeviceConnectionHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected iDeviceConnectionHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.iDevice
         protected iDeviceConnectionHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static iDeviceConnectionHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.iDevice
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.iDevice.idevice_disconnect(this.handle) == iDeviceError.Success);
+            return (this.Api.iDevice.idevice_disconnect(this.handle) == iDeviceError.Success);
         }
         
         public static iDeviceConnectionHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)

--- a/iMobileDevice/iDevice/iDeviceHandle.cs
+++ b/iMobileDevice/iDevice/iDeviceHandle.cs
@@ -17,6 +17,8 @@ namespace iMobileDevice.iDevice
     public partial class iDeviceHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
     {
         
+        private ILibiMobileDevice api;
+        
         protected iDeviceHandle() : 
                 base(true)
         {
@@ -25,6 +27,18 @@ namespace iMobileDevice.iDevice
         protected iDeviceHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
         }
         
         public static iDeviceHandle Zero
@@ -39,7 +53,7 @@ namespace iMobileDevice.iDevice
         protected override bool ReleaseHandle()
         {
             System.Diagnostics.Debug.WriteLine("Releasing {0} {1}", this.GetType().Name, this.handle);
-            return (LibiMobileDevice.Instance.iDevice.idevice_free(this.handle) == iDeviceError.Success);
+            return (this.Api.iDevice.idevice_free(this.handle) == iDeviceError.Success);
         }
         
         public static iDeviceHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)


### PR DESCRIPTION
Handles: Don't use the .Instance property to identify the instance of the API to use to release the handle, but track the API which was used to create the handle at creation time.