### PR TITLE
Generate code for the iDeviceActivation API

### DIFF
--- a/download.cmd
+++ b/download.cmd
@@ -1,5 +1,6 @@
 set USBMUXD_VERSION=104
 set LIBIMOBILEDEVICE_VERSION=142
+set LIBIDEVICEACTIVATION_VERSION=18
 wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/usbmuxd-osx-x64-1.1.0-%USBMUXD_VERSION%.tar.gz -O ext\usbmuxd-osx-x64-1.1.0-%USBMUXD_VERSION%.tar.gz
 REM wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/usbmuxd-linux-arm-1.1.0-%USBMUXD_VERSION%.tar.gz -O ext\usbmuxd-linux-arm-1.1.0-%USBMUXD_VERSION%.tar.gz
 REM wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/usbmuxd-linux-arm64-1.1.0-%USBMUXD_VERSION%.tar.gz -O ext\usbmuxd-linux-arm64-1.1.0-%USBMUXD_VERSION%.tar.gz
@@ -8,6 +9,8 @@ wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/libimobiledevice-osx-
 REM wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/libimobiledevice-linux-arm64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar.gz -O ext\libimobiledevice-linux-arm64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar.gz
 REM wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/libimobiledevice-linux-arm-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar.gz -O ext\libimobiledevice-linux-arm-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar.gz
 wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/libimobiledevice-linux-x64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar.gz -O ext\libimobiledevice-linux-x64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar.gz
+wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/libideviceactivation-linux-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar.gz -O ext\libideviceactivation-linux-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar.gz
+wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/libideviceactivation-osx-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar.gz -O ext\libideviceactivation-osx-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar.gz
 
 REM extract tar file from tar.gz
 7z x -aos ext\usbmuxd-osx-x64-1.1.0-%USBMUXD_VERSION%.tar.gz -oext\
@@ -18,9 +21,11 @@ REM 7z x -aos ext\usbmuxd-linux-arm64-1.1.0-%USBMUXD_VERSION%.tar.gz -oext\
 REM 7z x -aos ext\libimobiledevice-linux-arm64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar.gz -oext\
 REM 7z x -aos ext\libimobiledevice-linux-arm-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar.gz -oext\
 7z x -aos ext\libimobiledevice-linux-x64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar.gz -oext\
+7z x -aos ext\libideviceactivation-linux-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar.gz -oext\
+7z x -aos ext\libideviceactivation-osx-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar.gz -oext\
 
 REM extract files from the tar files
-7z x -aos ext\usbmuxd-osx-x64-1.1.0-%USBMUXD_VERSION%.tar -oext\osx-64
+7z x -aos ext\usbmuxd-osx-x64-1.1.0-%USBMUXD_VERSION%.tar -oext\osx-x64
 REM 7z x -aos ext\usbmuxd-linux-arm-1.1.0-%USBMUXD_VERSION%.tar -oext\debian-arm
 REM 7z x -aos ext\usbmuxd-linux-arm64-1.1.0-%USBMUXD_VERSION%.tar -oext\debian-arm64
 7z x -aos ext\usbmuxd-linux-x64-1.1.0-%USBMUXD_VERSION%.tar -oext\debian-x64
@@ -28,3 +33,5 @@ REM 7z x -aos ext\usbmuxd-linux-arm64-1.1.0-%USBMUXD_VERSION%.tar -oext\debian-a
 REM 7z x -aos ext\libimobiledevice-linux-arm64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar -oext\debian-arm64
 REM 7z x -aos ext\libimobiledevice-linux-arm-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar -oext\debian-arm
 7z x -aos ext\libimobiledevice-linux-x64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar -oext\debian-x64
+7z x -aos ext\libideviceactivation-linux-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar -oext\debian-x64
+7z x -aos ext\libideviceactivation-osx-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar -oext\osx-x64

--- a/iMobileDevice-net/ILibiMobileDevice.cs
+++ b/iMobileDevice-net/ILibiMobileDevice.cs
@@ -12,6 +12,7 @@ namespace iMobileDevice
 {
     using iMobileDevice.Usbmuxd;
     using iMobileDevice.Plist;
+    using iMobileDevice.iDeviceActivation;
     using iMobileDevice.iDevice;
     using iMobileDevice.Lockdown;
     using iMobileDevice.Afc;
@@ -47,6 +48,11 @@ namespace iMobileDevice
         }
         
         IPlistApi Plist
+        {
+            get;
+        }
+        
+        IiDeviceActivationApi iDeviceActivation
         {
             get;
         }

--- a/iMobileDevice-net/LibiMobileDevice.cs
+++ b/iMobileDevice-net/LibiMobileDevice.cs
@@ -12,6 +12,7 @@ namespace iMobileDevice
 {
     using iMobileDevice.Usbmuxd;
     using iMobileDevice.Plist;
+    using iMobileDevice.iDeviceActivation;
     using iMobileDevice.iDevice;
     using iMobileDevice.Lockdown;
     using iMobileDevice.Afc;
@@ -46,6 +47,8 @@ namespace iMobileDevice
         private IUsbmuxdApi usbmuxd;
         
         private IPlistApi plist;
+        
+        private IiDeviceActivationApi ideviceActivation;
         
         private IiDeviceApi idevice;
         
@@ -99,6 +102,7 @@ namespace iMobileDevice
         {
             this.usbmuxd = new UsbmuxdApi(this);
             this.plist = new PlistApi(this);
+            this.ideviceActivation = new iDeviceActivationApi(this);
             this.idevice = new iDeviceApi(this);
             this.lockdown = new LockdownApi(this);
             this.afc = new AfcApi(this);
@@ -158,6 +162,18 @@ namespace iMobileDevice
             set
             {
                 this.plist = value;
+            }
+        }
+        
+        public virtual IiDeviceActivationApi iDeviceActivation
+        {
+            get
+            {
+                return this.ideviceActivation;
+            }
+            set
+            {
+                this.ideviceActivation = value;
             }
         }
         

--- a/iMobileDevice-net/iDeviceactivation/IiDeviceActivationApi.cs
+++ b/iMobileDevice-net/iDeviceactivation/IiDeviceActivationApi.cs
@@ -1,0 +1,82 @@
+// <copyright file="IiDeviceActivationApi.cs" company="Quamotion">
+// Copyright (c) 2016-2018 Quamotion. All rights reserved.
+// </copyright>
+
+namespace iMobileDevice.iDeviceActivation
+{
+    using System.Runtime.InteropServices;
+    using System.Diagnostics;
+    using iMobileDevice.iDevice;
+    using iMobileDevice.Lockdown;
+    using iMobileDevice.Afc;
+    using iMobileDevice.Plist;
+    
+    
+    public partial interface IiDeviceActivationApi
+    {
+        
+        /// <summary>
+        /// Gets or sets the <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="iDeviceActivation"/>.
+        /// </summary>
+        ILibiMobileDevice Parent
+        {
+            get;
+        }
+        
+        void idevice_activation_set_debug_level(int level);
+        
+        iDeviceActivationError idevice_activation_request_new(iDeviceActivationClientType activationType, out iDeviceActivationRequestHandle request);
+        
+        iDeviceActivationError idevice_activation_request_new_from_lockdownd(iDeviceActivationClientType activationType, System.IntPtr lockdown, out iDeviceActivationRequestHandle request);
+        
+        iDeviceActivationError idevice_activation_drm_handshake_request_new(iDeviceActivationClientType clientType, out iDeviceActivationRequestHandle request);
+        
+        void idevice_activation_request_free(System.IntPtr request);
+        
+        void idevice_activation_request_get_fields(iDeviceActivationRequestHandle request, out PlistHandle fields);
+        
+        void idevice_activation_request_set_fields(iDeviceActivationRequestHandle request, PlistHandle fields);
+        
+        void idevice_activation_request_set_fields_from_response(iDeviceActivationRequestHandle request, iDeviceActivationResponseHandle response);
+        
+        void idevice_activation_request_set_field(iDeviceActivationRequestHandle request, string key, string value);
+        
+        void idevice_activation_request_get_field(iDeviceActivationRequestHandle request, string key, out string value);
+        
+        void idevice_activation_request_get_url(iDeviceActivationRequestHandle request, out string url);
+        
+        void idevice_activation_request_set_url(iDeviceActivationRequestHandle request, string url);
+        
+        iDeviceActivationError idevice_activation_response_new(out iDeviceActivationResponseHandle response);
+        
+        iDeviceActivationError idevice_activation_response_new_from_html(string content, out iDeviceActivationResponseHandle response);
+        
+        iDeviceActivationError idevice_activation_response_to_buffer(iDeviceActivationResponseHandle response, out string buffer, ref uint size);
+        
+        void idevice_activation_response_free(System.IntPtr response);
+        
+        void idevice_activation_response_get_field(iDeviceActivationResponseHandle response, string key, out string value);
+        
+        void idevice_activation_response_get_fields(iDeviceActivationResponseHandle response, out PlistHandle fields);
+        
+        void idevice_activation_response_get_label(iDeviceActivationResponseHandle response, string key, out string value);
+        
+        void idevice_activation_response_get_title(iDeviceActivationResponseHandle response, out string title);
+        
+        void idevice_activation_response_get_description(iDeviceActivationResponseHandle response, out string description);
+        
+        void idevice_activation_response_get_activation_record(iDeviceActivationResponseHandle response, out PlistHandle activationRecord);
+        
+        void idevice_activation_response_get_headers(iDeviceActivationResponseHandle response, out PlistHandle headers);
+        
+        int idevice_activation_response_is_activation_acknowledged(iDeviceActivationResponseHandle response);
+        
+        int idevice_activation_response_is_authentication_required(iDeviceActivationResponseHandle response);
+        
+        int idevice_activation_response_field_requires_input(iDeviceActivationResponseHandle response, string key);
+        
+        int idevice_activation_response_has_errors(iDeviceActivationResponseHandle response);
+        
+        iDeviceActivationError idevice_activation_send_request(iDeviceActivationRequestHandle request, out iDeviceActivationResponseHandle response);
+    }
+}

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationApi.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationApi.cs
@@ -1,0 +1,201 @@
+// <copyright file="iDeviceActivationApi.cs" company="Quamotion">
+// Copyright (c) 2016-2018 Quamotion. All rights reserved.
+// </copyright>
+
+namespace iMobileDevice.iDeviceActivation
+{
+    using System.Runtime.InteropServices;
+    using System.Diagnostics;
+    using iMobileDevice.iDevice;
+    using iMobileDevice.Lockdown;
+    using iMobileDevice.Afc;
+    using iMobileDevice.Plist;
+    
+    
+    public partial class iDeviceActivationApi : IiDeviceActivationApi
+    {
+        
+        /// <summary>
+        /// Backing field for the <see cref="Parent"/> property
+        /// </summary>
+        private ILibiMobileDevice parent;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref"iDeviceActivationApi"/> class
+        /// </summary>
+        /// <param name="parent">
+        /// The <see cref="ILibiMobileDeviceApi"/> which owns this <see cref="iDeviceActivation"/>.
+        /// </summary>
+        public iDeviceActivationApi(ILibiMobileDevice parent)
+        {
+            this.parent = parent;
+        }
+        
+        /// <inheritdoc/>
+        public ILibiMobileDevice Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+        }
+        
+        public virtual void idevice_activation_set_debug_level(int level)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_set_debug_level(level);
+        }
+        
+        public virtual iDeviceActivationError idevice_activation_request_new(iDeviceActivationClientType activationType, out iDeviceActivationRequestHandle request)
+        {
+            iDeviceActivationError returnValue;
+            returnValue = iDeviceActivationNativeMethods.idevice_activation_request_new(activationType, out request);
+            request.Api = this.Parent;
+            return returnValue;
+        }
+        
+        public virtual iDeviceActivationError idevice_activation_request_new_from_lockdownd(iDeviceActivationClientType activationType, System.IntPtr lockdown, out iDeviceActivationRequestHandle request)
+        {
+            iDeviceActivationError returnValue;
+            returnValue = iDeviceActivationNativeMethods.idevice_activation_request_new_from_lockdownd(activationType, lockdown, out request);
+            request.Api = this.Parent;
+            return returnValue;
+        }
+        
+        public virtual iDeviceActivationError idevice_activation_drm_handshake_request_new(iDeviceActivationClientType clientType, out iDeviceActivationRequestHandle request)
+        {
+            iDeviceActivationError returnValue;
+            returnValue = iDeviceActivationNativeMethods.idevice_activation_drm_handshake_request_new(clientType, out request);
+            request.Api = this.Parent;
+            return returnValue;
+        }
+        
+        public virtual void idevice_activation_request_free(System.IntPtr request)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_request_free(request);
+        }
+        
+        public virtual void idevice_activation_request_get_fields(iDeviceActivationRequestHandle request, out PlistHandle fields)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_request_get_fields(request, out fields);
+        }
+        
+        public virtual void idevice_activation_request_set_fields(iDeviceActivationRequestHandle request, PlistHandle fields)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_request_set_fields(request, fields);
+        }
+        
+        public virtual void idevice_activation_request_set_fields_from_response(iDeviceActivationRequestHandle request, iDeviceActivationResponseHandle response)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_request_set_fields_from_response(request, response);
+        }
+        
+        public virtual void idevice_activation_request_set_field(iDeviceActivationRequestHandle request, string key, string value)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_request_set_field(request, key, value);
+        }
+        
+        public virtual void idevice_activation_request_get_field(iDeviceActivationRequestHandle request, string key, out string value)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_request_get_field(request, key, out value);
+        }
+        
+        public virtual void idevice_activation_request_get_url(iDeviceActivationRequestHandle request, out string url)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_request_get_url(request, out url);
+        }
+        
+        public virtual void idevice_activation_request_set_url(iDeviceActivationRequestHandle request, string url)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_request_set_url(request, url);
+        }
+        
+        public virtual iDeviceActivationError idevice_activation_response_new(out iDeviceActivationResponseHandle response)
+        {
+            iDeviceActivationError returnValue;
+            returnValue = iDeviceActivationNativeMethods.idevice_activation_response_new(out response);
+            response.Api = this.Parent;
+            return returnValue;
+        }
+        
+        public virtual iDeviceActivationError idevice_activation_response_new_from_html(string content, out iDeviceActivationResponseHandle response)
+        {
+            iDeviceActivationError returnValue;
+            returnValue = iDeviceActivationNativeMethods.idevice_activation_response_new_from_html(content, out response);
+            response.Api = this.Parent;
+            return returnValue;
+        }
+        
+        public virtual iDeviceActivationError idevice_activation_response_to_buffer(iDeviceActivationResponseHandle response, out string buffer, ref uint size)
+        {
+            return iDeviceActivationNativeMethods.idevice_activation_response_to_buffer(response, out buffer, ref size);
+        }
+        
+        public virtual void idevice_activation_response_free(System.IntPtr response)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_response_free(response);
+        }
+        
+        public virtual void idevice_activation_response_get_field(iDeviceActivationResponseHandle response, string key, out string value)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_response_get_field(response, key, out value);
+        }
+        
+        public virtual void idevice_activation_response_get_fields(iDeviceActivationResponseHandle response, out PlistHandle fields)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_response_get_fields(response, out fields);
+        }
+        
+        public virtual void idevice_activation_response_get_label(iDeviceActivationResponseHandle response, string key, out string value)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_response_get_label(response, key, out value);
+        }
+        
+        public virtual void idevice_activation_response_get_title(iDeviceActivationResponseHandle response, out string title)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_response_get_title(response, out title);
+        }
+        
+        public virtual void idevice_activation_response_get_description(iDeviceActivationResponseHandle response, out string description)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_response_get_description(response, out description);
+        }
+        
+        public virtual void idevice_activation_response_get_activation_record(iDeviceActivationResponseHandle response, out PlistHandle activationRecord)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_response_get_activation_record(response, out activationRecord);
+        }
+        
+        public virtual void idevice_activation_response_get_headers(iDeviceActivationResponseHandle response, out PlistHandle headers)
+        {
+            iDeviceActivationNativeMethods.idevice_activation_response_get_headers(response, out headers);
+        }
+        
+        public virtual int idevice_activation_response_is_activation_acknowledged(iDeviceActivationResponseHandle response)
+        {
+            return iDeviceActivationNativeMethods.idevice_activation_response_is_activation_acknowledged(response);
+        }
+        
+        public virtual int idevice_activation_response_is_authentication_required(iDeviceActivationResponseHandle response)
+        {
+            return iDeviceActivationNativeMethods.idevice_activation_response_is_authentication_required(response);
+        }
+        
+        public virtual int idevice_activation_response_field_requires_input(iDeviceActivationResponseHandle response, string key)
+        {
+            return iDeviceActivationNativeMethods.idevice_activation_response_field_requires_input(response, key);
+        }
+        
+        public virtual int idevice_activation_response_has_errors(iDeviceActivationResponseHandle response)
+        {
+            return iDeviceActivationNativeMethods.idevice_activation_response_has_errors(response);
+        }
+        
+        public virtual iDeviceActivationError idevice_activation_send_request(iDeviceActivationRequestHandle request, out iDeviceActivationResponseHandle response)
+        {
+            iDeviceActivationError returnValue;
+            returnValue = iDeviceActivationNativeMethods.idevice_activation_send_request(request, out response);
+            response.Api = this.Parent;
+            return returnValue;
+        }
+    }
+}

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationClientType.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationClientType.cs
@@ -1,0 +1,22 @@
+// <copyright file="iDeviceActivationClientType.cs" company="Quamotion">
+// Copyright (c) 2016-2018 Quamotion. All rights reserved.
+// </copyright>
+
+namespace iMobileDevice.iDeviceActivation
+{
+    using System.Runtime.InteropServices;
+    using System.Diagnostics;
+    using iMobileDevice.iDevice;
+    using iMobileDevice.Lockdown;
+    using iMobileDevice.Afc;
+    using iMobileDevice.Plist;
+    
+    
+    public enum iDeviceActivationClientType : int
+    {
+        
+        ClientMobileActivation = 0,
+        
+        ClientItunes = 1,
+    }
+}

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationError.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationError.cs
@@ -1,0 +1,36 @@
+// <copyright file="iDeviceActivationError.cs" company="Quamotion">
+// Copyright (c) 2016-2018 Quamotion. All rights reserved.
+// </copyright>
+
+namespace iMobileDevice.iDeviceActivation
+{
+    using System.Runtime.InteropServices;
+    using System.Diagnostics;
+    using iMobileDevice.iDevice;
+    using iMobileDevice.Lockdown;
+    using iMobileDevice.Afc;
+    using iMobileDevice.Plist;
+    
+    
+    public enum iDeviceActivationError : int
+    {
+        
+        Success = 0,
+        
+        IncompleteInfo = -1,
+        
+        OutOfMemory = -2,
+        
+        UnknownContentType = -3,
+        
+        BuddymlParsingError = -4,
+        
+        PlistParsingError = -5,
+        
+        HtmlParsingError = -6,
+        
+        UnsupportedFieldType = -7,
+        
+        InternalError = -255,
+    }
+}

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationErrorExtensions.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationErrorExtensions.cs
@@ -1,0 +1,39 @@
+// <copyright file="iDeviceActivationErrorExtensions.cs" company="Quamotion">
+// Copyright (c) 2016-2018 Quamotion. All rights reserved.
+// </copyright>
+
+namespace iMobileDevice.iDeviceActivation
+{
+    using System.Runtime.InteropServices;
+    using System.Diagnostics;
+    using iMobileDevice.iDevice;
+    using iMobileDevice.Lockdown;
+    using iMobileDevice.Afc;
+    using iMobileDevice.Plist;
+    
+    
+    public static class iDeviceActivationErrorExtensions
+    {
+        
+        public static void ThrowOnError(this iDeviceActivationError value)
+        {
+            if ((value != iDeviceActivationError.Success))
+            {
+                throw new iDeviceActivationException(value);
+            }
+        }
+        
+        public static void ThrowOnError(this iDeviceActivationError value, string message)
+        {
+            if ((value != iDeviceActivationError.Success))
+            {
+                throw new iDeviceActivationException(value, message);
+            }
+        }
+        
+        public static bool IsError(this iDeviceActivationError value)
+        {
+            return (value != iDeviceActivationError.Success);
+        }
+    }
+}

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationException.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationException.cs
@@ -1,0 +1,113 @@
+// <copyright file="iDeviceActivationException.cs" company="Quamotion">
+// Copyright (c) 2016-2018 Quamotion. All rights reserved.
+// </copyright>
+
+namespace iMobileDevice.iDeviceActivation
+{
+    using System.Runtime.InteropServices;
+    using System.Diagnostics;
+    using iMobileDevice.iDevice;
+    using iMobileDevice.Lockdown;
+    using iMobileDevice.Afc;
+    using iMobileDevice.Plist;
+    
+    
+    /// Represents an exception that occurred when interacting with the iDeviceActivation API.
+#if !NETSTANDARD1_5
+    [System.SerializableAttribute()]
+#endif
+    public class iDeviceActivationException : System.Exception
+    {
+        
+        /// <summary>
+        /// Backing field for the <see cref="ErrorCode"/> property.
+        /// </summary>
+        private iDeviceActivationError errorCode;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="iDeviceActivationException"/> class.
+        /// </summary>
+        public iDeviceActivationException()
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="iDeviceActivationException"/> class with a specified error code.
+        /// <summary>
+        /// <param name="error">
+        /// The error code of the error that occurred.
+        /// </param>
+        public iDeviceActivationException(iDeviceActivationError error) : 
+                base(string.Format("An iDeviceActivation error occurred. The error code was {0}", error))
+        {
+            this.errorCode = error;
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="iDeviceActivationException"/> class with a specified error code and error message.
+        /// <summary>
+        /// <param name="error">
+        /// The error code of the error that occurred.
+        /// </param>
+        /// <param name="message">
+        /// A message which describes the error.
+        /// </param>
+        public iDeviceActivationException(iDeviceActivationError error, string message) : 
+                base(string.Format("An iDeviceActivation error occurred. {1}. The error code was {0}", error, message))
+        {
+            this.errorCode = error;
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="iDeviceActivationException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">
+        /// The message that describes the error.
+        /// </param>
+        public iDeviceActivationException(string message) : 
+                base(message)
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="iDeviceActivationException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">
+        /// The error message that explains the reason for the exception.
+        /// </param>
+        /// <param name="inner">
+        /// The exception that is the cause of the current exception, or <see langword="null"/> if no inner exception is specified.
+        /// </param>
+        public iDeviceActivationException(string message, System.Exception inner) : 
+                base(message, inner)
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="iDeviceActivationException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">
+        /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.
+        /// </param>
+        /// <param name="context">
+        /// The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.
+        /// </param>
+#if !NETSTANDARD1_5
+        protected iDeviceActivationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : 
+                base(info, context)
+        {
+        }
+#endif
+        
+        /// <summary>
+        /// Gets the error code that represents the error.
+        /// </summary>
+        public virtual iDeviceActivationError ErrorCode
+        {
+            get
+            {
+                return this.errorCode;
+            }
+        }
+    }
+}

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationNativeMethods.Extensions.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationNativeMethods.Extensions.cs
@@ -1,0 +1,82 @@
+// <copyright file="iDeviceActivationNativeMethods.cs" company="Quamotion">
+// Copyright (c) 2016-2018 Quamotion. All rights reserved.
+// </copyright>
+
+namespace iMobileDevice.iDeviceActivation
+{
+    using System.Runtime.InteropServices;
+    using System.Diagnostics;
+    using iMobileDevice.iDevice;
+    using iMobileDevice.Lockdown;
+    using iMobileDevice.Afc;
+    using iMobileDevice.Plist;
+    
+    
+    public partial class iDeviceActivationNativeMethods
+    {
+        
+        public static void idevice_activation_request_get_field(iDeviceActivationRequestHandle request, string key, out string value)
+        {
+            System.Runtime.InteropServices.ICustomMarshaler valueMarshaler = NativeStringMarshaler.GetInstance(null);
+            System.IntPtr valueNative = System.IntPtr.Zero;
+            iDeviceActivationNativeMethods.idevice_activation_request_get_field(request, key, out valueNative);
+            value = ((string)valueMarshaler.MarshalNativeToManaged(valueNative));
+            valueMarshaler.CleanUpNativeData(valueNative);
+        }
+        
+        public static void idevice_activation_request_get_url(iDeviceActivationRequestHandle request, out string url)
+        {
+            System.Runtime.InteropServices.ICustomMarshaler urlMarshaler = NativeStringMarshaler.GetInstance(null);
+            System.IntPtr urlNative = System.IntPtr.Zero;
+            iDeviceActivationNativeMethods.idevice_activation_request_get_url(request, out urlNative);
+            url = ((string)urlMarshaler.MarshalNativeToManaged(urlNative));
+            urlMarshaler.CleanUpNativeData(urlNative);
+        }
+        
+        public static iDeviceActivationError idevice_activation_response_to_buffer(iDeviceActivationResponseHandle response, out string buffer, ref uint size)
+        {
+            System.Runtime.InteropServices.ICustomMarshaler bufferMarshaler = NativeStringMarshaler.GetInstance(null);
+            System.IntPtr bufferNative = System.IntPtr.Zero;
+            iDeviceActivationError returnValue = iDeviceActivationNativeMethods.idevice_activation_response_to_buffer(response, out bufferNative, ref size);
+            buffer = ((string)bufferMarshaler.MarshalNativeToManaged(bufferNative));
+            bufferMarshaler.CleanUpNativeData(bufferNative);
+            return returnValue;
+        }
+        
+        public static void idevice_activation_response_get_field(iDeviceActivationResponseHandle response, string key, out string value)
+        {
+            System.Runtime.InteropServices.ICustomMarshaler valueMarshaler = NativeStringMarshaler.GetInstance(null);
+            System.IntPtr valueNative = System.IntPtr.Zero;
+            iDeviceActivationNativeMethods.idevice_activation_response_get_field(response, key, out valueNative);
+            value = ((string)valueMarshaler.MarshalNativeToManaged(valueNative));
+            valueMarshaler.CleanUpNativeData(valueNative);
+        }
+        
+        public static void idevice_activation_response_get_label(iDeviceActivationResponseHandle response, string key, out string value)
+        {
+            System.Runtime.InteropServices.ICustomMarshaler valueMarshaler = NativeStringMarshaler.GetInstance(null);
+            System.IntPtr valueNative = System.IntPtr.Zero;
+            iDeviceActivationNativeMethods.idevice_activation_response_get_label(response, key, out valueNative);
+            value = ((string)valueMarshaler.MarshalNativeToManaged(valueNative));
+            valueMarshaler.CleanUpNativeData(valueNative);
+        }
+        
+        public static void idevice_activation_response_get_title(iDeviceActivationResponseHandle response, out string title)
+        {
+            System.Runtime.InteropServices.ICustomMarshaler titleMarshaler = NativeStringMarshaler.GetInstance(null);
+            System.IntPtr titleNative = System.IntPtr.Zero;
+            iDeviceActivationNativeMethods.idevice_activation_response_get_title(response, out titleNative);
+            title = ((string)titleMarshaler.MarshalNativeToManaged(titleNative));
+            titleMarshaler.CleanUpNativeData(titleNative);
+        }
+        
+        public static void idevice_activation_response_get_description(iDeviceActivationResponseHandle response, out string description)
+        {
+            System.Runtime.InteropServices.ICustomMarshaler descriptionMarshaler = NativeStringMarshaler.GetInstance(null);
+            System.IntPtr descriptionNative = System.IntPtr.Zero;
+            iDeviceActivationNativeMethods.idevice_activation_response_get_description(response, out descriptionNative);
+            description = ((string)descriptionMarshaler.MarshalNativeToManaged(descriptionNative));
+            descriptionMarshaler.CleanUpNativeData(descriptionNative);
+        }
+    }
+}

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationNativeMethods.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationNativeMethods.cs
@@ -1,0 +1,104 @@
+// <copyright file="iDeviceActivationNativeMethods.cs" company="Quamotion">
+// Copyright (c) 2016-2018 Quamotion. All rights reserved.
+// </copyright>
+
+namespace iMobileDevice.iDeviceActivation
+{
+    using System.Runtime.InteropServices;
+    using System.Diagnostics;
+    using iMobileDevice.iDevice;
+    using iMobileDevice.Lockdown;
+    using iMobileDevice.Afc;
+    using iMobileDevice.Plist;
+    
+    
+    public partial class iDeviceActivationNativeMethods
+    {
+        
+        const string libraryName = "ideviceactivation";
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_set_debug_level", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_set_debug_level(int level);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_request_new", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern iDeviceActivationError idevice_activation_request_new(iDeviceActivationClientType activationType, out iDeviceActivationRequestHandle request);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_request_new_from_lockdownd", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern iDeviceActivationError idevice_activation_request_new_from_lockdownd(iDeviceActivationClientType activationType, System.IntPtr lockdown, out iDeviceActivationRequestHandle request);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_drm_handshake_request_new", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern iDeviceActivationError idevice_activation_drm_handshake_request_new(iDeviceActivationClientType clientType, out iDeviceActivationRequestHandle request);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_request_free", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_request_free(System.IntPtr request);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_request_get_fields", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_request_get_fields(iDeviceActivationRequestHandle request, out PlistHandle fields);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_request_set_fields", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_request_set_fields(iDeviceActivationRequestHandle request, PlistHandle fields);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_request_set_fields_from_response", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_request_set_fields_from_response(iDeviceActivationRequestHandle request, iDeviceActivationResponseHandle response);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_request_set_field", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_request_set_field(iDeviceActivationRequestHandle request, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.LPStr)] string key, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.LPStr)] string value);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_request_get_field", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_request_get_field(iDeviceActivationRequestHandle request, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.LPStr)] string key, out System.IntPtr value);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_request_get_url", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_request_get_url(iDeviceActivationRequestHandle request, out System.IntPtr url);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_request_set_url", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_request_set_url(iDeviceActivationRequestHandle request, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.LPStr)] string url);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_response_new", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern iDeviceActivationError idevice_activation_response_new(out iDeviceActivationResponseHandle response);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_response_new_from_html", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern iDeviceActivationError idevice_activation_response_new_from_html([System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.LPStr)] string content, out iDeviceActivationResponseHandle response);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_response_to_buffer", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern iDeviceActivationError idevice_activation_response_to_buffer(iDeviceActivationResponseHandle response, out System.IntPtr buffer, ref uint size);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_response_free", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_response_free(System.IntPtr response);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_response_get_field", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_response_get_field(iDeviceActivationResponseHandle response, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.LPStr)] string key, out System.IntPtr value);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_response_get_fields", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_response_get_fields(iDeviceActivationResponseHandle response, out PlistHandle fields);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_response_get_label", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_response_get_label(iDeviceActivationResponseHandle response, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.LPStr)] string key, out System.IntPtr value);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_response_get_title", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_response_get_title(iDeviceActivationResponseHandle response, out System.IntPtr title);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_response_get_description", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_response_get_description(iDeviceActivationResponseHandle response, out System.IntPtr description);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_response_get_activation_record", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_response_get_activation_record(iDeviceActivationResponseHandle response, out PlistHandle activationRecord);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_response_get_headers", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern void idevice_activation_response_get_headers(iDeviceActivationResponseHandle response, out PlistHandle headers);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_response_is_activation_acknowledged", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern int idevice_activation_response_is_activation_acknowledged(iDeviceActivationResponseHandle response);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_response_is_authentication_required", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern int idevice_activation_response_is_authentication_required(iDeviceActivationResponseHandle response);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_response_field_requires_input", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern int idevice_activation_response_field_requires_input(iDeviceActivationResponseHandle response, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.LPStr)] string key);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_response_has_errors", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern int idevice_activation_response_has_errors(iDeviceActivationResponseHandle response);
+        
+        [System.Runtime.InteropServices.DllImportAttribute(iDeviceActivationNativeMethods.libraryName, EntryPoint="idevice_activation_send_request", CallingConvention=System.Runtime.InteropServices.CallingConvention.Cdecl)]
+        public static extern iDeviceActivationError idevice_activation_send_request(iDeviceActivationRequestHandle request, out iDeviceActivationResponseHandle response);
+    }
+}

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationRequestHandle.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationRequestHandle.cs
@@ -1,0 +1,105 @@
+// <copyright file="iDeviceActivationRequestHandle.cs" company="Quamotion">
+// Copyright (c) 2016-2018 Quamotion. All rights reserved.
+// </copyright>
+
+namespace iMobileDevice.iDeviceActivation
+{
+    using System.Runtime.InteropServices;
+    using System.Diagnostics;
+    using iMobileDevice.iDevice;
+    using iMobileDevice.Lockdown;
+    using iMobileDevice.Afc;
+    using iMobileDevice.Plist;
+    
+    
+#if !NETSTANDARD1_5
+    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+#endif
+#if !NETSTANDARD1_5
+    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
+#endif
+    public partial class iDeviceActivationRequestHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    {
+        
+        private string creationStackTrace;
+        
+        private ILibiMobileDevice api;
+        
+        protected iDeviceActivationRequestHandle() : 
+                base(true)
+        {
+            this.creationStackTrace = System.Environment.StackTrace;
+        }
+        
+        protected iDeviceActivationRequestHandle(bool ownsHandle) : 
+                base(ownsHandle)
+        {
+            this.creationStackTrace = System.Environment.StackTrace;
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
+        }
+        
+        public static iDeviceActivationRequestHandle Zero
+        {
+            get
+            {
+                return iDeviceActivationRequestHandle.DangerousCreate(System.IntPtr.Zero);
+            }
+        }
+        
+#if !NETSTANDARD1_5
+        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
+#endif
+        protected override bool ReleaseHandle()
+        {
+            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            this.Api.iDeviceActivation.idevice_activation_request_free(this.handle);
+            return true;
+        }
+        
+        public static iDeviceActivationRequestHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
+        {
+            iDeviceActivationRequestHandle safeHandle;
+            safeHandle = new iDeviceActivationRequestHandle(ownsHandle);
+            safeHandle.SetHandle(unsafeHandle);
+            return safeHandle;
+        }
+        
+        public static iDeviceActivationRequestHandle DangerousCreate(System.IntPtr unsafeHandle)
+        {
+            return iDeviceActivationRequestHandle.DangerousCreate(unsafeHandle, true);
+        }
+        
+        public override string ToString()
+        {
+            return string.Format("{0} ({1})", this.handle, "iDeviceActivationRequestHandle");
+        }
+        
+        public override bool Equals(object obj)
+        {
+            if (((obj != null) & (obj.GetType() == typeof(iDeviceActivationRequestHandle))))
+            {
+                return ((iDeviceActivationRequestHandle)obj).handle.Equals(this.handle);
+            }
+            else
+            {
+                return false;
+            }
+        }
+        
+        public override int GetHashCode()
+        {
+            return this.handle.GetHashCode();
+        }
+    }
+}

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationRequestHandleDelegateMarshaler.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationRequestHandleDelegateMarshaler.cs
@@ -1,0 +1,46 @@
+// <copyright file="iDeviceActivationRequestHandleDelegateMarshaler.cs" company="Quamotion">
+// Copyright (c) 2016-2018 Quamotion. All rights reserved.
+// </copyright>
+
+namespace iMobileDevice.iDeviceActivation
+{
+    using System.Runtime.InteropServices;
+    using System.Diagnostics;
+    using iMobileDevice.iDevice;
+    using iMobileDevice.Lockdown;
+    using iMobileDevice.Afc;
+    using iMobileDevice.Plist;
+    
+    
+    public partial class iDeviceActivationRequestHandleDelegateMarshaler : System.Runtime.InteropServices.ICustomMarshaler
+    {
+        
+        public static System.Runtime.InteropServices.ICustomMarshaler GetInstance(string cookie)
+        {
+            return new iDeviceActivationRequestHandleDelegateMarshaler();
+        }
+        
+        public void CleanUpManagedData(object managedObject)
+        {
+        }
+        
+        public void CleanUpNativeData(System.IntPtr nativeData)
+        {
+        }
+        
+        public int GetNativeDataSize()
+        {
+            return -1;
+        }
+        
+        public System.IntPtr MarshalManagedToNative(object managedObject)
+        {
+            return System.IntPtr.Zero;
+        }
+        
+        public object MarshalNativeToManaged(System.IntPtr nativeData)
+        {
+            return iDeviceActivationRequestHandle.DangerousCreate(nativeData, false);
+        }
+    }
+}

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationResponseHandle.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationResponseHandle.cs
@@ -1,0 +1,105 @@
+// <copyright file="iDeviceActivationResponseHandle.cs" company="Quamotion">
+// Copyright (c) 2016-2018 Quamotion. All rights reserved.
+// </copyright>
+
+namespace iMobileDevice.iDeviceActivation
+{
+    using System.Runtime.InteropServices;
+    using System.Diagnostics;
+    using iMobileDevice.iDevice;
+    using iMobileDevice.Lockdown;
+    using iMobileDevice.Afc;
+    using iMobileDevice.Plist;
+    
+    
+#if !NETSTANDARD1_5
+    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+#endif
+#if !NETSTANDARD1_5
+    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
+#endif
+    public partial class iDeviceActivationResponseHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    {
+        
+        private string creationStackTrace;
+        
+        private ILibiMobileDevice api;
+        
+        protected iDeviceActivationResponseHandle() : 
+                base(true)
+        {
+            this.creationStackTrace = System.Environment.StackTrace;
+        }
+        
+        protected iDeviceActivationResponseHandle(bool ownsHandle) : 
+                base(ownsHandle)
+        {
+            this.creationStackTrace = System.Environment.StackTrace;
+        }
+        
+        public ILibiMobileDevice Api
+        {
+            get
+            {
+                return this.api;
+            }
+            set
+            {
+                this.api = value;
+            }
+        }
+        
+        public static iDeviceActivationResponseHandle Zero
+        {
+            get
+            {
+                return iDeviceActivationResponseHandle.DangerousCreate(System.IntPtr.Zero);
+            }
+        }
+        
+#if !NETSTANDARD1_5
+        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
+#endif
+        protected override bool ReleaseHandle()
+        {
+            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            this.Api.iDeviceActivation.idevice_activation_response_free(this.handle);
+            return true;
+        }
+        
+        public static iDeviceActivationResponseHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
+        {
+            iDeviceActivationResponseHandle safeHandle;
+            safeHandle = new iDeviceActivationResponseHandle(ownsHandle);
+            safeHandle.SetHandle(unsafeHandle);
+            return safeHandle;
+        }
+        
+        public static iDeviceActivationResponseHandle DangerousCreate(System.IntPtr unsafeHandle)
+        {
+            return iDeviceActivationResponseHandle.DangerousCreate(unsafeHandle, true);
+        }
+        
+        public override string ToString()
+        {
+            return string.Format("{0} ({1})", this.handle, "iDeviceActivationResponseHandle");
+        }
+        
+        public override bool Equals(object obj)
+        {
+            if (((obj != null) & (obj.GetType() == typeof(iDeviceActivationResponseHandle))))
+            {
+                return ((iDeviceActivationResponseHandle)obj).handle.Equals(this.handle);
+            }
+            else
+            {
+                return false;
+            }
+        }
+        
+        public override int GetHashCode()
+        {
+            return this.handle.GetHashCode();
+        }
+    }
+}

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationResponseHandleDelegateMarshaler.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationResponseHandleDelegateMarshaler.cs
@@ -1,0 +1,46 @@
+// <copyright file="iDeviceActivationResponseHandleDelegateMarshaler.cs" company="Quamotion">
+// Copyright (c) 2016-2018 Quamotion. All rights reserved.
+// </copyright>
+
+namespace iMobileDevice.iDeviceActivation
+{
+    using System.Runtime.InteropServices;
+    using System.Diagnostics;
+    using iMobileDevice.iDevice;
+    using iMobileDevice.Lockdown;
+    using iMobileDevice.Afc;
+    using iMobileDevice.Plist;
+    
+    
+    public partial class iDeviceActivationResponseHandleDelegateMarshaler : System.Runtime.InteropServices.ICustomMarshaler
+    {
+        
+        public static System.Runtime.InteropServices.ICustomMarshaler GetInstance(string cookie)
+        {
+            return new iDeviceActivationResponseHandleDelegateMarshaler();
+        }
+        
+        public void CleanUpManagedData(object managedObject)
+        {
+        }
+        
+        public void CleanUpNativeData(System.IntPtr nativeData)
+        {
+        }
+        
+        public int GetNativeDataSize()
+        {
+            return -1;
+        }
+        
+        public System.IntPtr MarshalManagedToNative(object managedObject)
+        {
+            return System.IntPtr.Zero;
+        }
+        
+        public object MarshalNativeToManaged(System.IntPtr nativeData)
+        {
+            return iDeviceActivationResponseHandle.DangerousCreate(nativeData, false);
+        }
+    }
+}

--- a/iMobileDevice-net/iMobileDevice-net.csproj
+++ b/iMobileDevice-net/iMobileDevice-net.csproj
@@ -93,6 +93,18 @@
       <PackagePath>runtimes/win7-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
+    <Content Include="$(MSBuildThisFileDirectory)\..\packages\curl.redist.7.30.0.2\build\native\bin\v110\x64\Release\dynamic\*.dll">
+      <PackagePath>runtimes/win7-x64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)\..\packages\libxml2.redist.2.7.8.7\build\native\bin\v110\x64\Release\dynamic\cdecl\*.dll">
+      <PackagePath>runtimes/win7-x64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)\..\packages\libssh2.redist.1.4.3.1\build\native\bin\v110\x64\Release\dynamic\cdecl\*.dll">
+      <PackagePath>runtimes/win7-x64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
 
     <!-- win7-x86 files which come from NuGet packages-->
     <Content Include="$(MSBuildThisFileDirectory)\..\packages\ideviceinstaller.redist.1.1.0.19\build\native\bin\Win32\v140\Release\*.*">
@@ -144,6 +156,18 @@
       <Pack>true</Pack>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)\..\packages\pthreads.redist.2.9.1.4\build\native\bin\v110\Win32\Release\dynamic\cdecl\*.dll">
+      <PackagePath>runtimes/win7-x86/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)\..\packages\curl.redist.7.30.0.2\build\native\bin\v110\Win32\Release\dynamic\*.dll">
+      <PackagePath>runtimes/win7-x86/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)\..\packages\libxml2.redist.2.7.8.7\build\native\bin\v110\Win32\Release\dynamic\cdecl\*.dll">
+      <PackagePath>runtimes/win7-x86/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)\..\packages\libssh2.redist.1.4.3.1\build\native\bin\v110\Win32\Release\dynamic\cdecl\*.dll">
       <PackagePath>runtimes/win7-x86/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>

--- a/iMobileDevice-net/iMobileDevice-net.csproj
+++ b/iMobileDevice-net/iMobileDevice-net.csproj
@@ -57,6 +57,14 @@
       <PackagePath>runtimes/win7-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
+    <Content Include="$(MSBuildThisFileDirectory)/../packages/libideviceactivation.redist.1.0.0.23/build/native/bin/x64/v140/Release/*.*">
+      <PackagePath>runtimes/win7-x64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)/../packages/libideviceactivation.symbols.1.0.0.23/build/native/bin/x64/v140/Release/*.pdb">
+      <PackagePath>runtimes/win7-x64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
     <Content Include="$(MSBuildThisFileDirectory)\..\packages\usbmuxd.1.1.0.106\runtimes\win7-x64\native\*.exe">
       <PackagePath>runtimes/win7-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
@@ -101,6 +109,14 @@
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)\..\packages\libimobiledevice.symbols.1.2.1.196\build\native\bin\Win32\v140\Release\*.pdb">
       <PackagePath>runtimes/win7-x86/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)/../packages/libideviceactivation.redist.1.0.0.23/build/native/bin/Win32/v140/Release/*.*">
+      <PackagePath>runtimes/win7-x64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)/../packages/libideviceactivation.symbols.1.0.0.23/build/native/bin/Win32/v140/Release/*.pdb">
+      <PackagePath>runtimes/win7-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)\..\packages\usbmuxd.1.1.0.106\runtimes\win7-x86\native\*.exe">

--- a/iMobileDevice-net/iMobileDevice-net.csproj
+++ b/iMobileDevice-net/iMobileDevice-net.csproj
@@ -100,7 +100,7 @@
       <Pack>true</Pack>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)/../packages/libzip.redist.1.1.2.7/build/native/bin/Win32/v140/Release/*.*">
-      <PackagePath>runtimes/win7-x64/native/%(Filename)%(Extension)</PackagePath>
+      <PackagePath>runtimes/win7-x86/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)\..\packages\libimobiledevice.redist.1.2.1.196\build\native\bin\Win32\v140\Release\*.*">
@@ -112,11 +112,11 @@
       <Pack>true</Pack>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)/../packages/libideviceactivation.redist.1.0.0.23/build/native/bin/Win32/v140/Release/*.*">
-      <PackagePath>runtimes/win7-x64/native/%(Filename)%(Extension)</PackagePath>
+      <PackagePath>runtimes/win7-x86/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)/../packages/libideviceactivation.symbols.1.0.0.23/build/native/bin/Win32/v140/Release/*.pdb">
-      <PackagePath>runtimes/win7-x64/native/%(Filename)%(Extension)</PackagePath>
+      <PackagePath>runtimes/win7-x86/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)\..\packages\usbmuxd.1.1.0.106\runtimes\win7-x86\native\*.exe">

--- a/iMobileDevice.Generator/ModuleGenerator.cs
+++ b/iMobileDevice.Generator/ModuleGenerator.cs
@@ -80,7 +80,7 @@ namespace iMobileDevice.Generator
             this.NameMapping.Add(nativeName, type.Name);
         }
 
-        public void Generate(string targetDirectory)
+        public void Generate(string targetDirectory, string libraryName = "imobiledevice")
         {
             var createIndex = clang.createIndex(0, 0);
 
@@ -158,7 +158,7 @@ namespace iMobileDevice.Generator
             clang.visitChildren(clang.getTranslationUnitCursor(translationUnit), typeDefVisitor.Visit, new CXClientData(IntPtr.Zero));
 
             // Creates functions in a NativeMethods class
-            var functionVisitor = new FunctionVisitor(this, "imobiledevice");
+            var functionVisitor = new FunctionVisitor(this, libraryName);
             clang.visitChildren(clang.getTranslationUnitCursor(translationUnit), functionVisitor.Visit, new CXClientData(IntPtr.Zero));
 
             clang.disposeTranslationUnit(translationUnit);

--- a/iMobileDevice.Generator/NameConversions.cs
+++ b/iMobileDevice.Generator/NameConversions.cs
@@ -20,6 +20,8 @@ namespace iMobileDevice.Generator
             patchedName = patchedName.Replace("PROPERTY_LIST_SERVICE", "propertylistservice");
             patchedName = patchedName.Replace("SYSLOG_RELAY", "syslogrelay");
             patchedName = patchedName.Replace("FILE_RELAY", "filerelay");
+            patchedName = patchedName.Replace("IDEVICE_ACTIVATION", "ideviceactivation");
+            patchedName = patchedName.Replace("libideviceactivation", "ideviceactivation");
 
             List<string> parts = new List<string>(patchedName.Split('_'));
 
@@ -138,6 +140,11 @@ namespace iMobileDevice.Generator
                 {
                     parts[i] = "File";
                     parts.Insert(i + 1, "Relay");
+                }
+                else if (parts[i] == "ideviceactivation")
+                {
+                    parts[i] = "iDevice";
+                    parts.Insert(i + 1, "Activation");
                 }
 
                 if (conversion == NameConversion.Parameter && i == 0)

--- a/iMobileDevice.Generator/Program.cs
+++ b/iMobileDevice.Generator/Program.cs
@@ -73,7 +73,16 @@ namespace iMobileDevice.Generator
             {
                 Console.WriteLine($"Processing {Path.GetFileName(file)}");
                 generator.InputFile = file;
-                generator.Generate(targetDirectory);
+
+                if (string.Equals(Path.GetFileName(file), "libideviceactivation.h", StringComparison.OrdinalIgnoreCase))
+                {
+                    generator.Generate(targetDirectory, "ideviceactivation");
+                }
+                else
+                {
+                    generator.Generate(targetDirectory);
+                }
+
                 generator.Types.Clear();
 
                 names.Add(generator.Name);

--- a/iMobileDevice.Generator/Program.cs
+++ b/iMobileDevice.Generator/Program.cs
@@ -50,12 +50,14 @@ namespace iMobileDevice.Generator
             generator.IncludeDirectories.Add(Path.Combine(sourceDirectory, @"packages\libusbmuxd.1.0.10.86\build\native\include\"));
             generator.IncludeDirectories.Add(Path.Combine(sourceDirectory, @"packages\libimobiledevice.1.2.1.196\build\native\include\"));
             generator.IncludeDirectories.Add(Path.Combine(sourceDirectory, @"packages\libplist.2.0.1.171\build\native\include"));
+            generator.IncludeDirectories.Add(Path.Combine(sourceDirectory, @"packages\libideviceactivation.1.0.0.23\build\native\include\libideviceactivation"));
 
             Collection<string> names = new Collection<string>();
 
             var files = new List<string>();
             files.Add(Path.Combine(sourceDirectory, @"packages\libusbmuxd.1.0.10.86\build\native\include\usbmuxd.h"));
             files.Add(Path.Combine(sourceDirectory, @"packages\libplist.2.0.1.171\build\native\include\plist\plist.h"));
+            files.Add(Path.Combine(sourceDirectory, @"packages\libideviceactivation.1.0.0.23\build\native\include\libideviceactivation\libideviceactivation.h"));
 
             var iMobileDeviceDirectory = Path.Combine(sourceDirectory, @"packages\libimobiledevice.1.2.1.196\build\native\include\libimobiledevice");
             files.Add(Path.Combine(iMobileDeviceDirectory, "libimobiledevice.h"));

--- a/iMobileDevice.Generator/packages.config
+++ b/iMobileDevice.Generator/packages.config
@@ -13,6 +13,9 @@
   <package id="libusbmuxd" version="1.0.10.86" targetFramework="native" />
   <package id="libusbmuxd.redist" version="1.0.10.86" targetFramework="native" />
   <package id="libusbmuxd.symbols" version="1.0.10.86" targetFramework="native" />
+  <package id="libideviceactivation" version="1.0.0.23" targetFramework="native" />
+  <package id="libideviceactivation.redist" version="1.0.0.23" targetFramework="native" />
+  <package id="libideviceactivation.symbols" version="1.0.0.23" targetFramework="native" />
   <package id="usbmuxd" version="1.1.0.106" targetFramework="native" />
   <package id="libiconv" version="1.14.0.11" targetFramework="native" />
   <package id="ClangSharp" version="3.6.0" targetFramework="net452" />

--- a/iMobileDevice.Generator/packages.config
+++ b/iMobileDevice.Generator/packages.config
@@ -46,4 +46,10 @@
   <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net452" />
   <package id="System.Threading" version="4.0.0" targetFramework="net452" />
   <package id="zlib.v140.windesktop.msvcstl.dyn.rt-dyn" version="1.2.8.8" targetFramework="native" />
+  <package id="curl" version="7.30.0.2" targetFramework="native" />
+  <package id="curl.redist" version="7.30.0.2" targetFramework="native" />
+  <package id="libxml2" version="2.7.8.7" targetFramework="native" />
+  <package id="libxml2.redist" version="2.7.8.7" targetFramework="native" />
+  <package id="libssh2" version="1.4.3.1" targetFramework="native" />
+  <package id="libssh2.redist" version="1.4.3.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
This PR adds support for libideviceactivation.

The native library is build as a CoApp package and consumed as a NuGet reference.
The generator then generates code for libideviceactivation.

Unlike other libraries (libplist, libusbmuxd) which end up in imobiledevice, libideviceactivation ends up in ideviceactivation, so the code generator needed some changes to enable us to specify the name of the native library.