### PR TITLE
Add ==, != operators and documentation to Handles

### DIFF
--- a/iMobileDevice-net/Afc/AfcClientHandle.cs
+++ b/iMobileDevice-net/Afc/AfcClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.Afc
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="AfcClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (AfcClientHandle value1, AfcClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="AfcClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (AfcClientHandle value1, AfcClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/Afc/AfcClientHandle.cs
+++ b/iMobileDevice-net/Afc/AfcClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.Afc
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AfcClientHandle"/> class.
+        /// </summary>
         protected AfcClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AfcClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected AfcClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.Afc
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static AfcClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.Afc
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.Afc
             return (this.Api.Afc.afc_client_free(this.handle) == AfcError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="AfcClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static AfcClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             AfcClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.Afc
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="AfcClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static AfcClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return AfcClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "AfcClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(AfcClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.Afc
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/DebugServer/DebugServerClientHandle.cs
+++ b/iMobileDevice-net/DebugServer/DebugServerClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.DebugServer
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="DebugServerClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (DebugServerClientHandle value1, DebugServerClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="DebugServerClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (DebugServerClientHandle value1, DebugServerClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/DebugServer/DebugServerClientHandle.cs
+++ b/iMobileDevice-net/DebugServer/DebugServerClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.DebugServer
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DebugServerClientHandle"/> class.
+        /// </summary>
         protected DebugServerClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DebugServerClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected DebugServerClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.DebugServer
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static DebugServerClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.DebugServer
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.DebugServer
             return (this.Api.DebugServer.debugserver_client_free(this.handle) == DebugServerError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="DebugServerClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static DebugServerClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             DebugServerClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.DebugServer
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="DebugServerClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static DebugServerClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return DebugServerClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "DebugServerClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(DebugServerClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.DebugServer
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/DebugServer/DebugServerCommandHandle.cs
+++ b/iMobileDevice-net/DebugServer/DebugServerCommandHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.DebugServer
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DebugServerCommandHandle"/> class.
+        /// </summary>
         protected DebugServerCommandHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DebugServerCommandHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected DebugServerCommandHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.DebugServer
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static DebugServerCommandHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.DebugServer
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.DebugServer
             return (this.Api.DebugServer.debugserver_command_free(this.handle) == DebugServerError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="DebugServerCommandHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static DebugServerCommandHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             DebugServerCommandHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.DebugServer
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="DebugServerCommandHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static DebugServerCommandHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return DebugServerCommandHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "DebugServerCommandHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(DebugServerCommandHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.DebugServer
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/DebugServer/DebugServerCommandHandle.cs
+++ b/iMobileDevice-net/DebugServer/DebugServerCommandHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.DebugServer
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="DebugServerCommandHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (DebugServerCommandHandle value1, DebugServerCommandHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="DebugServerCommandHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (DebugServerCommandHandle value1, DebugServerCommandHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/DiagnosticsRelay/DiagnosticsRelayClientHandle.cs
+++ b/iMobileDevice-net/DiagnosticsRelay/DiagnosticsRelayClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.DiagnosticsRelay
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="DiagnosticsRelayClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (DiagnosticsRelayClientHandle value1, DiagnosticsRelayClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="DiagnosticsRelayClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (DiagnosticsRelayClientHandle value1, DiagnosticsRelayClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/DiagnosticsRelay/DiagnosticsRelayClientHandle.cs
+++ b/iMobileDevice-net/DiagnosticsRelay/DiagnosticsRelayClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.DiagnosticsRelay
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DiagnosticsRelayClientHandle"/> class.
+        /// </summary>
         protected DiagnosticsRelayClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DiagnosticsRelayClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected DiagnosticsRelayClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.DiagnosticsRelay
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static DiagnosticsRelayClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.DiagnosticsRelay
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.DiagnosticsRelay
             return (this.Api.DiagnosticsRelay.diagnostics_relay_client_free(this.handle) == DiagnosticsRelayError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="DiagnosticsRelayClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static DiagnosticsRelayClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             DiagnosticsRelayClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.DiagnosticsRelay
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="DiagnosticsRelayClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static DiagnosticsRelayClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return DiagnosticsRelayClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "DiagnosticsRelayClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(DiagnosticsRelayClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.DiagnosticsRelay
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/FileRelay/FileRelayClientHandle.cs
+++ b/iMobileDevice-net/FileRelay/FileRelayClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.FileRelay
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileRelayClientHandle"/> class.
+        /// </summary>
         protected FileRelayClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileRelayClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected FileRelayClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.FileRelay
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static FileRelayClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.FileRelay
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.FileRelay
             return (this.Api.FileRelay.file_relay_client_free(this.handle) == FileRelayError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="FileRelayClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static FileRelayClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             FileRelayClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.FileRelay
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="FileRelayClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static FileRelayClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return FileRelayClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "FileRelayClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(FileRelayClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.FileRelay
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/FileRelay/FileRelayClientHandle.cs
+++ b/iMobileDevice-net/FileRelay/FileRelayClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.FileRelay
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="FileRelayClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (FileRelayClientHandle value1, FileRelayClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="FileRelayClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (FileRelayClientHandle value1, FileRelayClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/HeartBeat/HeartBeatClientHandle.cs
+++ b/iMobileDevice-net/HeartBeat/HeartBeatClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.HeartBeat
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HeartBeatClientHandle"/> class.
+        /// </summary>
         protected HeartBeatClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HeartBeatClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected HeartBeatClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.HeartBeat
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static HeartBeatClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.HeartBeat
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.HeartBeat
             return (this.Api.HeartBeat.heartbeat_client_free(this.handle) == HeartBeatError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="HeartBeatClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static HeartBeatClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             HeartBeatClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.HeartBeat
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="HeartBeatClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static HeartBeatClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return HeartBeatClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "HeartBeatClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(HeartBeatClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.HeartBeat
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/HeartBeat/HeartBeatClientHandle.cs
+++ b/iMobileDevice-net/HeartBeat/HeartBeatClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.HeartBeat
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="HeartBeatClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (HeartBeatClientHandle value1, HeartBeatClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="HeartBeatClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (HeartBeatClientHandle value1, HeartBeatClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/HouseArrest/HouseArrestClientHandle.cs
+++ b/iMobileDevice-net/HouseArrest/HouseArrestClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.HouseArrest
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="HouseArrestClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (HouseArrestClientHandle value1, HouseArrestClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="HouseArrestClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (HouseArrestClientHandle value1, HouseArrestClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/HouseArrest/HouseArrestClientHandle.cs
+++ b/iMobileDevice-net/HouseArrest/HouseArrestClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.HouseArrest
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HouseArrestClientHandle"/> class.
+        /// </summary>
         protected HouseArrestClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HouseArrestClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected HouseArrestClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.HouseArrest
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static HouseArrestClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.HouseArrest
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.HouseArrest
             return (this.Api.HouseArrest.house_arrest_client_free(this.handle) == HouseArrestError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="HouseArrestClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static HouseArrestClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             HouseArrestClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.HouseArrest
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="HouseArrestClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static HouseArrestClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return HouseArrestClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "HouseArrestClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(HouseArrestClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.HouseArrest
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/InstallationProxy/InstallationProxyClientHandle.cs
+++ b/iMobileDevice-net/InstallationProxy/InstallationProxyClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.InstallationProxy
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="InstallationProxyClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (InstallationProxyClientHandle value1, InstallationProxyClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="InstallationProxyClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (InstallationProxyClientHandle value1, InstallationProxyClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/InstallationProxy/InstallationProxyClientHandle.cs
+++ b/iMobileDevice-net/InstallationProxy/InstallationProxyClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.InstallationProxy
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstallationProxyClientHandle"/> class.
+        /// </summary>
         protected InstallationProxyClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstallationProxyClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected InstallationProxyClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.InstallationProxy
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static InstallationProxyClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.InstallationProxy
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.InstallationProxy
             return (this.Api.InstallationProxy.instproxy_client_free(this.handle) == InstallationProxyError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="InstallationProxyClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static InstallationProxyClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             InstallationProxyClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.InstallationProxy
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="InstallationProxyClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static InstallationProxyClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return InstallationProxyClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "InstallationProxyClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(InstallationProxyClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.InstallationProxy
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/Lockdown/LockdownClientHandle.cs
+++ b/iMobileDevice-net/Lockdown/LockdownClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.Lockdown
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="LockdownClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (LockdownClientHandle value1, LockdownClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="LockdownClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (LockdownClientHandle value1, LockdownClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/Lockdown/LockdownClientHandle.cs
+++ b/iMobileDevice-net/Lockdown/LockdownClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.Lockdown
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LockdownClientHandle"/> class.
+        /// </summary>
         protected LockdownClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LockdownClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected LockdownClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.Lockdown
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static LockdownClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.Lockdown
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.Lockdown
             return (this.Api.Lockdown.lockdownd_client_free(this.handle) == LockdownError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="LockdownClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static LockdownClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             LockdownClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.Lockdown
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="LockdownClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static LockdownClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return LockdownClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "LockdownClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(LockdownClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.Lockdown
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/Lockdown/LockdownPairRecordHandle.cs
+++ b/iMobileDevice-net/Lockdown/LockdownPairRecordHandle.cs
@@ -99,5 +99,39 @@ namespace iMobileDevice.Lockdown
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="LockdownPairRecordHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (LockdownPairRecordHandle value1, LockdownPairRecordHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="LockdownPairRecordHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (LockdownPairRecordHandle value1, LockdownPairRecordHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/Lockdown/LockdownPairRecordHandle.cs
+++ b/iMobileDevice-net/Lockdown/LockdownPairRecordHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.Lockdown
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LockdownPairRecordHandle"/> class.
+        /// </summary>
         protected LockdownPairRecordHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LockdownPairRecordHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected LockdownPairRecordHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.Lockdown
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static LockdownPairRecordHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.Lockdown
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -65,6 +81,17 @@ namespace iMobileDevice.Lockdown
             return true;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="LockdownPairRecordHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static LockdownPairRecordHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             LockdownPairRecordHandle safeHandle;
@@ -73,16 +100,26 @@ namespace iMobileDevice.Lockdown
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="LockdownPairRecordHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static LockdownPairRecordHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return LockdownPairRecordHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "LockdownPairRecordHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(LockdownPairRecordHandle))))
@@ -95,6 +132,7 @@ namespace iMobileDevice.Lockdown
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/Lockdown/LockdownServiceDescriptorHandle.cs
+++ b/iMobileDevice-net/Lockdown/LockdownServiceDescriptorHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.Lockdown
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="LockdownServiceDescriptorHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (LockdownServiceDescriptorHandle value1, LockdownServiceDescriptorHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="LockdownServiceDescriptorHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (LockdownServiceDescriptorHandle value1, LockdownServiceDescriptorHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/Lockdown/LockdownServiceDescriptorHandle.cs
+++ b/iMobileDevice-net/Lockdown/LockdownServiceDescriptorHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.Lockdown
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LockdownServiceDescriptorHandle"/> class.
+        /// </summary>
         protected LockdownServiceDescriptorHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LockdownServiceDescriptorHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected LockdownServiceDescriptorHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.Lockdown
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static LockdownServiceDescriptorHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.Lockdown
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.Lockdown
             return (this.Api.Lockdown.lockdownd_service_descriptor_free(this.handle) == LockdownError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="LockdownServiceDescriptorHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static LockdownServiceDescriptorHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             LockdownServiceDescriptorHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.Lockdown
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="LockdownServiceDescriptorHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static LockdownServiceDescriptorHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return LockdownServiceDescriptorHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "LockdownServiceDescriptorHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(LockdownServiceDescriptorHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.Lockdown
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/Misagent/MisagentClientHandle.cs
+++ b/iMobileDevice-net/Misagent/MisagentClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.Misagent
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MisagentClientHandle"/> class.
+        /// </summary>
         protected MisagentClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MisagentClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected MisagentClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.Misagent
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static MisagentClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.Misagent
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.Misagent
             return (this.Api.Misagent.misagent_client_free(this.handle) == MisagentError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="MisagentClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static MisagentClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             MisagentClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.Misagent
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="MisagentClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static MisagentClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return MisagentClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "MisagentClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(MisagentClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.Misagent
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/Misagent/MisagentClientHandle.cs
+++ b/iMobileDevice-net/Misagent/MisagentClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.Misagent
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MisagentClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (MisagentClientHandle value1, MisagentClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MisagentClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (MisagentClientHandle value1, MisagentClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/MobileBackup/MobileBackupClientHandle.cs
+++ b/iMobileDevice-net/MobileBackup/MobileBackupClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.MobileBackup
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileBackupClientHandle"/> class.
+        /// </summary>
         protected MobileBackupClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileBackupClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected MobileBackupClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.MobileBackup
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static MobileBackupClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.MobileBackup
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.MobileBackup
             return (this.Api.MobileBackup.mobilebackup_client_free(this.handle) == MobileBackupError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="MobileBackupClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static MobileBackupClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             MobileBackupClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.MobileBackup
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="MobileBackupClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static MobileBackupClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return MobileBackupClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "MobileBackupClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(MobileBackupClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.MobileBackup
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/MobileBackup/MobileBackupClientHandle.cs
+++ b/iMobileDevice-net/MobileBackup/MobileBackupClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.MobileBackup
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MobileBackupClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (MobileBackupClientHandle value1, MobileBackupClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MobileBackupClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (MobileBackupClientHandle value1, MobileBackupClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/MobileBackup2/MobileBackup2ClientHandle.cs
+++ b/iMobileDevice-net/MobileBackup2/MobileBackup2ClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.MobileBackup2
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileBackup2ClientHandle"/> class.
+        /// </summary>
         protected MobileBackup2ClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileBackup2ClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected MobileBackup2ClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.MobileBackup2
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static MobileBackup2ClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.MobileBackup2
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.MobileBackup2
             return (this.Api.MobileBackup2.mobilebackup2_client_free(this.handle) == MobileBackup2Error.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="MobileBackup2ClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static MobileBackup2ClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             MobileBackup2ClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.MobileBackup2
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="MobileBackup2ClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static MobileBackup2ClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return MobileBackup2ClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "MobileBackup2ClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(MobileBackup2ClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.MobileBackup2
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/MobileBackup2/MobileBackup2ClientHandle.cs
+++ b/iMobileDevice-net/MobileBackup2/MobileBackup2ClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.MobileBackup2
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MobileBackup2ClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (MobileBackup2ClientHandle value1, MobileBackup2ClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MobileBackup2ClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (MobileBackup2ClientHandle value1, MobileBackup2ClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/MobileImageMounter/MobileImageMounterClientHandle.cs
+++ b/iMobileDevice-net/MobileImageMounter/MobileImageMounterClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.MobileImageMounter
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileImageMounterClientHandle"/> class.
+        /// </summary>
         protected MobileImageMounterClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileImageMounterClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected MobileImageMounterClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.MobileImageMounter
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static MobileImageMounterClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.MobileImageMounter
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.MobileImageMounter
             return (this.Api.MobileImageMounter.mobile_image_mounter_free(this.handle) == MobileImageMounterError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="MobileImageMounterClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static MobileImageMounterClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             MobileImageMounterClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.MobileImageMounter
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="MobileImageMounterClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static MobileImageMounterClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return MobileImageMounterClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "MobileImageMounterClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(MobileImageMounterClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.MobileImageMounter
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/MobileImageMounter/MobileImageMounterClientHandle.cs
+++ b/iMobileDevice-net/MobileImageMounter/MobileImageMounterClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.MobileImageMounter
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MobileImageMounterClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (MobileImageMounterClientHandle value1, MobileImageMounterClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MobileImageMounterClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (MobileImageMounterClientHandle value1, MobileImageMounterClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/MobileSync/MobileSyncAnchorsHandle.cs
+++ b/iMobileDevice-net/MobileSync/MobileSyncAnchorsHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.MobileSync
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileSyncAnchorsHandle"/> class.
+        /// </summary>
         protected MobileSyncAnchorsHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileSyncAnchorsHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected MobileSyncAnchorsHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.MobileSync
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static MobileSyncAnchorsHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.MobileSync
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.MobileSync
             return (this.Api.MobileSync.mobilesync_anchors_free(this.handle) == MobileSyncError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="MobileSyncAnchorsHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static MobileSyncAnchorsHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             MobileSyncAnchorsHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.MobileSync
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="MobileSyncAnchorsHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static MobileSyncAnchorsHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return MobileSyncAnchorsHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "MobileSyncAnchorsHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(MobileSyncAnchorsHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.MobileSync
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/MobileSync/MobileSyncAnchorsHandle.cs
+++ b/iMobileDevice-net/MobileSync/MobileSyncAnchorsHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.MobileSync
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MobileSyncAnchorsHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (MobileSyncAnchorsHandle value1, MobileSyncAnchorsHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MobileSyncAnchorsHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (MobileSyncAnchorsHandle value1, MobileSyncAnchorsHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/MobileSync/MobileSyncClientHandle.cs
+++ b/iMobileDevice-net/MobileSync/MobileSyncClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.MobileSync
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileSyncClientHandle"/> class.
+        /// </summary>
         protected MobileSyncClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileSyncClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected MobileSyncClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.MobileSync
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static MobileSyncClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.MobileSync
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.MobileSync
             return (this.Api.MobileSync.mobilesync_client_free(this.handle) == MobileSyncError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="MobileSyncClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static MobileSyncClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             MobileSyncClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.MobileSync
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="MobileSyncClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static MobileSyncClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return MobileSyncClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "MobileSyncClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(MobileSyncClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.MobileSync
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/MobileSync/MobileSyncClientHandle.cs
+++ b/iMobileDevice-net/MobileSync/MobileSyncClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.MobileSync
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MobileSyncClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (MobileSyncClientHandle value1, MobileSyncClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MobileSyncClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (MobileSyncClientHandle value1, MobileSyncClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/Mobileactivation/MobileactivationClientHandle.cs
+++ b/iMobileDevice-net/Mobileactivation/MobileactivationClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.Mobileactivation
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MobileactivationClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (MobileactivationClientHandle value1, MobileactivationClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="MobileactivationClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (MobileactivationClientHandle value1, MobileactivationClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/Mobileactivation/MobileactivationClientHandle.cs
+++ b/iMobileDevice-net/Mobileactivation/MobileactivationClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.Mobileactivation
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileactivationClientHandle"/> class.
+        /// </summary>
         protected MobileactivationClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MobileactivationClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected MobileactivationClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.Mobileactivation
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static MobileactivationClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.Mobileactivation
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.Mobileactivation
             return (this.Api.Mobileactivation.mobileactivation_client_free(this.handle) == MobileactivationError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="MobileactivationClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static MobileactivationClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             MobileactivationClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.Mobileactivation
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="MobileactivationClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static MobileactivationClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return MobileactivationClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "MobileactivationClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(MobileactivationClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.Mobileactivation
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/NotificationProxy/NotificationProxyClientHandle.cs
+++ b/iMobileDevice-net/NotificationProxy/NotificationProxyClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.NotificationProxy
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotificationProxyClientHandle"/> class.
+        /// </summary>
         protected NotificationProxyClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotificationProxyClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected NotificationProxyClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.NotificationProxy
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static NotificationProxyClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.NotificationProxy
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.NotificationProxy
             return (this.Api.NotificationProxy.np_client_free(this.handle) == NotificationProxyError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="NotificationProxyClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static NotificationProxyClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             NotificationProxyClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.NotificationProxy
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="NotificationProxyClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static NotificationProxyClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return NotificationProxyClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "NotificationProxyClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(NotificationProxyClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.NotificationProxy
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/NotificationProxy/NotificationProxyClientHandle.cs
+++ b/iMobileDevice-net/NotificationProxy/NotificationProxyClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.NotificationProxy
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="NotificationProxyClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (NotificationProxyClientHandle value1, NotificationProxyClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="NotificationProxyClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (NotificationProxyClientHandle value1, NotificationProxyClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/Plist/PlistDictIterHandle.cs
+++ b/iMobileDevice-net/Plist/PlistDictIterHandle.cs
@@ -99,5 +99,39 @@ namespace iMobileDevice.Plist
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="PlistDictIterHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (PlistDictIterHandle value1, PlistDictIterHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="PlistDictIterHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (PlistDictIterHandle value1, PlistDictIterHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/Plist/PlistDictIterHandle.cs
+++ b/iMobileDevice-net/Plist/PlistDictIterHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.Plist
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlistDictIterHandle"/> class.
+        /// </summary>
         protected PlistDictIterHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlistDictIterHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected PlistDictIterHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.Plist
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static PlistDictIterHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.Plist
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -65,6 +81,17 @@ namespace iMobileDevice.Plist
             return true;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="PlistDictIterHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static PlistDictIterHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             PlistDictIterHandle safeHandle;
@@ -73,16 +100,26 @@ namespace iMobileDevice.Plist
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="PlistDictIterHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static PlistDictIterHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return PlistDictIterHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "PlistDictIterHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(PlistDictIterHandle))))
@@ -95,6 +132,7 @@ namespace iMobileDevice.Plist
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/Plist/PlistHandle.cs
+++ b/iMobileDevice-net/Plist/PlistHandle.cs
@@ -101,5 +101,39 @@ namespace iMobileDevice.Plist
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="PlistHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (PlistHandle value1, PlistHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="PlistHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (PlistHandle value1, PlistHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/Plist/PlistHandle.cs
+++ b/iMobileDevice-net/Plist/PlistHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.Plist
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlistHandle"/> class.
+        /// </summary>
         protected PlistHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlistHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected PlistHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.Plist
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static PlistHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.Plist
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -67,6 +83,17 @@ namespace iMobileDevice.Plist
             return true;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="PlistHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static PlistHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             PlistHandle safeHandle;
@@ -75,16 +102,26 @@ namespace iMobileDevice.Plist
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="PlistHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static PlistHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return PlistHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "PlistHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(PlistHandle))))
@@ -97,6 +134,7 @@ namespace iMobileDevice.Plist
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/PropertyListService/PropertyListServiceClientHandle.cs
+++ b/iMobileDevice-net/PropertyListService/PropertyListServiceClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.PropertyListService
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertyListServiceClientHandle"/> class.
+        /// </summary>
         protected PropertyListServiceClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertyListServiceClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected PropertyListServiceClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.PropertyListService
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static PropertyListServiceClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.PropertyListService
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.PropertyListService
             return (this.Api.PropertyListService.property_list_service_client_free(this.handle) == PropertyListServiceError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="PropertyListServiceClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static PropertyListServiceClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             PropertyListServiceClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.PropertyListService
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="PropertyListServiceClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static PropertyListServiceClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return PropertyListServiceClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "PropertyListServiceClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(PropertyListServiceClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.PropertyListService
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/PropertyListService/PropertyListServiceClientHandle.cs
+++ b/iMobileDevice-net/PropertyListService/PropertyListServiceClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.PropertyListService
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="PropertyListServiceClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (PropertyListServiceClientHandle value1, PropertyListServiceClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="PropertyListServiceClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (PropertyListServiceClientHandle value1, PropertyListServiceClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/Restore/RestoreClientHandle.cs
+++ b/iMobileDevice-net/Restore/RestoreClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.Restore
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RestoreClientHandle"/> class.
+        /// </summary>
         protected RestoreClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RestoreClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected RestoreClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.Restore
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static RestoreClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.Restore
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.Restore
             return (this.Api.Restore.restored_client_free(this.handle) == RestoreError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="RestoreClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static RestoreClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             RestoreClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.Restore
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="RestoreClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static RestoreClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return RestoreClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "RestoreClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(RestoreClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.Restore
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/Restore/RestoreClientHandle.cs
+++ b/iMobileDevice-net/Restore/RestoreClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.Restore
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="RestoreClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (RestoreClientHandle value1, RestoreClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="RestoreClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (RestoreClientHandle value1, RestoreClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/Screenshotr/ScreenshotrClientHandle.cs
+++ b/iMobileDevice-net/Screenshotr/ScreenshotrClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.Screenshotr
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="ScreenshotrClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (ScreenshotrClientHandle value1, ScreenshotrClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="ScreenshotrClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (ScreenshotrClientHandle value1, ScreenshotrClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/Screenshotr/ScreenshotrClientHandle.cs
+++ b/iMobileDevice-net/Screenshotr/ScreenshotrClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.Screenshotr
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScreenshotrClientHandle"/> class.
+        /// </summary>
         protected ScreenshotrClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScreenshotrClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected ScreenshotrClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.Screenshotr
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static ScreenshotrClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.Screenshotr
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.Screenshotr
             return (this.Api.Screenshotr.screenshotr_client_free(this.handle) == ScreenshotrError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="ScreenshotrClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static ScreenshotrClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             ScreenshotrClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.Screenshotr
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="ScreenshotrClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static ScreenshotrClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return ScreenshotrClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "ScreenshotrClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(ScreenshotrClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.Screenshotr
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/Service/ServiceClientHandle.cs
+++ b/iMobileDevice-net/Service/ServiceClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.Service
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="ServiceClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (ServiceClientHandle value1, ServiceClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="ServiceClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (ServiceClientHandle value1, ServiceClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/Service/ServiceClientHandle.cs
+++ b/iMobileDevice-net/Service/ServiceClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.Service
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceClientHandle"/> class.
+        /// </summary>
         protected ServiceClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected ServiceClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.Service
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static ServiceClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.Service
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.Service
             return (this.Api.Service.service_client_free(this.handle) == ServiceError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="ServiceClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static ServiceClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             ServiceClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.Service
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="ServiceClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static ServiceClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return ServiceClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "ServiceClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(ServiceClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.Service
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/SpringBoardServices/SpringBoardServicesClientHandle.cs
+++ b/iMobileDevice-net/SpringBoardServices/SpringBoardServicesClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.SpringBoardServices
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="SpringBoardServicesClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (SpringBoardServicesClientHandle value1, SpringBoardServicesClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="SpringBoardServicesClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (SpringBoardServicesClientHandle value1, SpringBoardServicesClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/SpringBoardServices/SpringBoardServicesClientHandle.cs
+++ b/iMobileDevice-net/SpringBoardServices/SpringBoardServicesClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.SpringBoardServices
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpringBoardServicesClientHandle"/> class.
+        /// </summary>
         protected SpringBoardServicesClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpringBoardServicesClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected SpringBoardServicesClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.SpringBoardServices
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static SpringBoardServicesClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.SpringBoardServices
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.SpringBoardServices
             return (this.Api.SpringBoardServices.sbservices_client_free(this.handle) == SpringBoardServicesError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="SpringBoardServicesClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static SpringBoardServicesClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             SpringBoardServicesClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.SpringBoardServices
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="SpringBoardServicesClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static SpringBoardServicesClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return SpringBoardServicesClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "SpringBoardServicesClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(SpringBoardServicesClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.SpringBoardServices
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/SyslogRelay/SyslogRelayClientHandle.cs
+++ b/iMobileDevice-net/SyslogRelay/SyslogRelayClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.SyslogRelay
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="SyslogRelayClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (SyslogRelayClientHandle value1, SyslogRelayClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="SyslogRelayClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (SyslogRelayClientHandle value1, SyslogRelayClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/SyslogRelay/SyslogRelayClientHandle.cs
+++ b/iMobileDevice-net/SyslogRelay/SyslogRelayClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.SyslogRelay
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SyslogRelayClientHandle"/> class.
+        /// </summary>
         protected SyslogRelayClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SyslogRelayClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected SyslogRelayClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.SyslogRelay
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static SyslogRelayClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.SyslogRelay
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.SyslogRelay
             return (this.Api.SyslogRelay.syslog_relay_client_free(this.handle) == SyslogRelayError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="SyslogRelayClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static SyslogRelayClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             SyslogRelayClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.SyslogRelay
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="SyslogRelayClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static SyslogRelayClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return SyslogRelayClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "SyslogRelayClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(SyslogRelayClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.SyslogRelay
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/WebInspector/WebInspectorClientHandle.cs
+++ b/iMobileDevice-net/WebInspector/WebInspectorClientHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.WebInspector
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebInspectorClientHandle"/> class.
+        /// </summary>
         protected WebInspectorClientHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebInspectorClientHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected WebInspectorClientHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.WebInspector
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static WebInspectorClientHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.WebInspector
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.WebInspector
             return (this.Api.WebInspector.webinspector_client_free(this.handle) == WebInspectorError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="WebInspectorClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static WebInspectorClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             WebInspectorClientHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.WebInspector
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="WebInspectorClientHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static WebInspectorClientHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return WebInspectorClientHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "WebInspectorClientHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(WebInspectorClientHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.WebInspector
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/WebInspector/WebInspectorClientHandle.cs
+++ b/iMobileDevice-net/WebInspector/WebInspectorClientHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.WebInspector
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="WebInspectorClientHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (WebInspectorClientHandle value1, WebInspectorClientHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="WebInspectorClientHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (WebInspectorClientHandle value1, WebInspectorClientHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/iDevice/iDeviceConnectionHandle.cs
+++ b/iMobileDevice-net/iDevice/iDeviceConnectionHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.iDevice
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="iDeviceConnectionHandle"/> class.
+        /// </summary>
         protected iDeviceConnectionHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="iDeviceConnectionHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected iDeviceConnectionHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.iDevice
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static iDeviceConnectionHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.iDevice
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.iDevice
             return (this.Api.iDevice.idevice_disconnect(this.handle) == iDeviceError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="iDeviceConnectionHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static iDeviceConnectionHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             iDeviceConnectionHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.iDevice
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="iDeviceConnectionHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static iDeviceConnectionHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return iDeviceConnectionHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "iDeviceConnectionHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(iDeviceConnectionHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.iDevice
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/iDevice/iDeviceConnectionHandle.cs
+++ b/iMobileDevice-net/iDevice/iDeviceConnectionHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.iDevice
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="iDeviceConnectionHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (iDeviceConnectionHandle value1, iDeviceConnectionHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="iDeviceConnectionHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (iDeviceConnectionHandle value1, iDeviceConnectionHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/iDevice/iDeviceHandle.cs
+++ b/iMobileDevice-net/iDevice/iDeviceHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.iDevice
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="iDeviceHandle"/> class.
+        /// </summary>
         protected iDeviceHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="iDeviceHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected iDeviceHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.iDevice
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static iDeviceHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.iDevice
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -66,6 +82,17 @@ namespace iMobileDevice.iDevice
             return (this.Api.iDevice.idevice_free(this.handle) == iDeviceError.Success);
         }
         
+        /// <summary>
+        /// Creates a new <see cref="iDeviceHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static iDeviceHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             iDeviceHandle safeHandle;
@@ -74,16 +101,26 @@ namespace iMobileDevice.iDevice
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="iDeviceHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static iDeviceHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return iDeviceHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "iDeviceHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(iDeviceHandle))))
@@ -96,6 +133,7 @@ namespace iMobileDevice.iDevice
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/iDevice/iDeviceHandle.cs
+++ b/iMobileDevice-net/iDevice/iDeviceHandle.cs
@@ -100,5 +100,39 @@ namespace iMobileDevice.iDevice
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="iDeviceHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (iDeviceHandle value1, iDeviceHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="iDeviceHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (iDeviceHandle value1, iDeviceHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationRequestHandle.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationRequestHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.iDeviceActivation
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="iDeviceActivationRequestHandle"/> class.
+        /// </summary>
         protected iDeviceActivationRequestHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="iDeviceActivationRequestHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected iDeviceActivationRequestHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.iDeviceActivation
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static iDeviceActivationRequestHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.iDeviceActivation
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -67,6 +83,17 @@ namespace iMobileDevice.iDeviceActivation
             return true;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="iDeviceActivationRequestHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static iDeviceActivationRequestHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             iDeviceActivationRequestHandle safeHandle;
@@ -75,16 +102,26 @@ namespace iMobileDevice.iDeviceActivation
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="iDeviceActivationRequestHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static iDeviceActivationRequestHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return iDeviceActivationRequestHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "iDeviceActivationRequestHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(iDeviceActivationRequestHandle))))
@@ -97,6 +134,7 @@ namespace iMobileDevice.iDeviceActivation
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationRequestHandle.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationRequestHandle.cs
@@ -101,5 +101,39 @@ namespace iMobileDevice.iDeviceActivation
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="iDeviceActivationRequestHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (iDeviceActivationRequestHandle value1, iDeviceActivationRequestHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="iDeviceActivationRequestHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (iDeviceActivationRequestHandle value1, iDeviceActivationRequestHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationResponseHandle.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationResponseHandle.cs
@@ -25,18 +25,30 @@ namespace iMobileDevice.iDeviceActivation
         
         private ILibiMobileDevice api;
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="iDeviceActivationResponseHandle"/> class.
+        /// </summary>
         protected iDeviceActivationResponseHandle() : 
                 base(true)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="iDeviceActivationResponseHandle"/> class, specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
         protected iDeviceActivationResponseHandle(bool ownsHandle) : 
                 base(ownsHandle)
         {
             this.creationStackTrace = System.Environment.StackTrace;
         }
         
+        /// <summary>
+        /// Gets or sets the API to use
+        /// </summary>
         public ILibiMobileDevice Api
         {
             get
@@ -49,6 +61,9 @@ namespace iMobileDevice.iDeviceActivation
             }
         }
         
+        /// <summary>
+        /// Gets a value which represents a pointer or handle that has been initialized to zero.
+        /// </summary>
         public static iDeviceActivationResponseHandle Zero
         {
             get
@@ -57,6 +72,7 @@ namespace iMobileDevice.iDeviceActivation
             }
         }
         
+        /// <inheritdoc/>
 #if !NETSTANDARD1_5
         [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
 #endif
@@ -67,6 +83,17 @@ namespace iMobileDevice.iDeviceActivation
             return true;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="iDeviceActivationResponseHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static iDeviceActivationResponseHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
             iDeviceActivationResponseHandle safeHandle;
@@ -75,16 +102,26 @@ namespace iMobileDevice.iDeviceActivation
             return safeHandle;
         }
         
+        /// <summary>
+        /// Creates a new <see cref="iDeviceActivationResponseHandle"/> from a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="unsafeHandle">
+        /// The underlying <see cref="IntPtr"/>
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static iDeviceActivationResponseHandle DangerousCreate(System.IntPtr unsafeHandle)
         {
             return iDeviceActivationResponseHandle.DangerousCreate(unsafeHandle, true);
         }
         
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format("{0} ({1})", this.handle, "iDeviceActivationResponseHandle");
         }
         
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (((obj != null) & (obj.GetType() == typeof(iDeviceActivationResponseHandle))))
@@ -97,6 +134,7 @@ namespace iMobileDevice.iDeviceActivation
             }
         }
         
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.handle.GetHashCode();

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationResponseHandle.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationResponseHandle.cs
@@ -101,5 +101,39 @@ namespace iMobileDevice.iDeviceActivation
         {
             return this.handle.GetHashCode();
         }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="iDeviceActivationResponseHandle"/> are equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> equals <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator == (iDeviceActivationResponseHandle value1, iDeviceActivationResponseHandle value2) 
+        {
+            return value1.handle == value2.handle;
+        }
+        
+        /// <summary>
+        /// Determines whether two specified instances of <see cref="iDeviceActivationResponseHandle"/> are not equal.
+        /// </summary>
+        /// <param name="value1">
+        /// The first pointer or handle to compare.
+        /// </param>
+        /// <param name="value2">
+        /// The second pointer or handle to compare.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="value1"/> does not equal <paramref name="value2"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator != (iDeviceActivationResponseHandle value1, iDeviceActivationResponseHandle value2) 
+        {
+            return value1.handle != value2.handle;
+        }
     }
 }

--- a/iMobileDevice.Generator/CodeDom/CSharpTextWriter.Members.cs
+++ b/iMobileDevice.Generator/CodeDom/CSharpTextWriter.Members.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.CodeDom;
+    using System.IO;
 
     partial class CSharpTextWriter
     {
@@ -18,6 +19,10 @@
             else if (member is CodeMemberProperty)
             {
                 this.Generate((CodeMemberProperty)member);
+            }
+            else if (member is CodeSnippetTypeMember)
+            {
+                this.Generate((CodeSnippetTypeMember)member);
             }
             else
             {
@@ -264,6 +269,17 @@
                 this.Generate(parameter.Type);
                 this.Write(" ");
                 this.WriteName(parameter.Name);
+            }
+        }
+
+        private void Generate(CodeSnippetTypeMember expression)
+        {
+            using (StringReader reader = new StringReader(expression.Text))
+            {
+                while (reader.Peek() >= 0)
+                {
+                    this.WriteLine(reader.ReadLine());
+                }
             }
         }
 

--- a/iMobileDevice.Generator/CodeDom/CSharpTextWriter.cs
+++ b/iMobileDevice.Generator/CodeDom/CSharpTextWriter.cs
@@ -138,6 +138,12 @@
                 this.Generate(member, isInterface: type.IsInterface);
             }
 
+            foreach (var member in type.Members.OfType<CodeSnippetTypeMember>())
+            {
+                this.WriteLine();
+                this.Generate(member);
+            }
+
             this.Indent--;
             this.WriteLine("}");
         }

--- a/iMobileDevice.Generator/Handles.cs
+++ b/iMobileDevice.Generator/Handles.cs
@@ -77,6 +77,9 @@ namespace iMobileDevice.Generator
             constructor.Attributes = MemberAttributes.Family;
             constructor.BaseConstructorArgs.Add(new CodePrimitiveExpression(true));
             constructor.Statements.Add(setCreationStackTrace);
+            constructor.Comments.Add(new CodeCommentStatement($@"<summary>
+Initializes a new instance of the <see cref=""{safeHandle.Name}""/> class.
+</summary>"));
             safeHandle.Members.Add(constructor);
 
             CodeConstructor ownsHandleConstructor = new CodeConstructor();
@@ -84,6 +87,12 @@ namespace iMobileDevice.Generator
             ownsHandleConstructor.Parameters.Add(new CodeParameterDeclarationExpression(new CodeTypeReference(typeof(bool)), "ownsHandle"));
             ownsHandleConstructor.BaseConstructorArgs.Add(new CodeArgumentReferenceExpression("ownsHandle"));
             ownsHandleConstructor.Statements.Add(setCreationStackTrace);
+            ownsHandleConstructor.Comments.Add(new CodeCommentStatement($@"<summary>
+Initializes a new instance of the <see cref=""{safeHandle.Name}""/> class, specifying whether the handle is to be reliably released.
+</summary>
+<param name=""ownsHandle"">
+<see langword=""true""/> to reliably release the handle during the finalization phase; <see langword=""false""/> to prevent reliable release (not recommended).
+</param>"));
             safeHandle.Members.Add(ownsHandleConstructor);
 
             CodeMemberMethod releaseHandle = new CodeMemberMethod();
@@ -91,6 +100,7 @@ namespace iMobileDevice.Generator
             releaseHandle.Attributes = MemberAttributes.Override | MemberAttributes.Family;
             releaseHandle.ReturnType = new CodeTypeReference(typeof(bool));
             releaseHandle.CustomAttributes.Add(ReliabilityContractDeclaration(Consistency.WillNotCorruptState, Cer.MayFail));
+            releaseHandle.Comments.Add(new CodeCommentStatement("<inheritdoc/>"));
 
             releaseHandle.Statements.Add(new CodeMethodReturnStatement(new CodePrimitiveExpression(true)));
             safeHandle.Members.Add(releaseHandle);
@@ -118,6 +128,9 @@ namespace iMobileDevice.Generator
                         apiField.Name),
                     new CodeVariableReferenceExpression("value")));
             apiProperty.Type = new CodeTypeReference("ILibiMobileDevice");
+            apiProperty.Comments.Add(new CodeCommentStatement(@"<summary>
+Gets or sets the API to use
+</summary>"));
             safeHandle.Members.Add(apiProperty);
 
             // Add a "DangeousCreate" method which creates a new safe handle from an IntPtr
@@ -125,6 +138,17 @@ namespace iMobileDevice.Generator
             dangerousCreate.Name = "DangerousCreate";
             dangerousCreate.Attributes = MemberAttributes.Public | MemberAttributes.Static;
             dangerousCreate.ReturnType = new CodeTypeReference(safeHandle.Name);
+            dangerousCreate.Comments.Add(new CodeCommentStatement($@"<summary>
+Creates a new <see cref=""{safeHandle.Name}""/> from a <see cref=""IntPtr""/>.
+</summary>
+<param name=""unsafeHandle"">
+The underlying <see cref=""IntPtr""/>
+</param>
+<param name=""ownsHandle"">
+<see langword=""true""/> to reliably release the handle during the finalization phase; <see langword=""false""/> to prevent reliable release (not recommended).
+</param>
+<returns>
+</returns>"));
 
             dangerousCreate.Parameters.Add(
                 new CodeParameterDeclarationExpression(
@@ -166,6 +190,14 @@ namespace iMobileDevice.Generator
             simpleDangerousCreate.Name = "DangerousCreate";
             simpleDangerousCreate.Attributes = MemberAttributes.Public | MemberAttributes.Static;
             simpleDangerousCreate.ReturnType = new CodeTypeReference(safeHandle.Name);
+            simpleDangerousCreate.Comments.Add(new CodeCommentStatement($@"<summary>
+Creates a new <see cref=""{safeHandle.Name}""/> from a <see cref=""IntPtr""/>.
+</summary>
+<param name=""unsafeHandle"">
+The underlying <see cref=""IntPtr""/>
+</param>
+<returns>
+</returns>"));
 
             simpleDangerousCreate.Parameters.Add(
                 new CodeParameterDeclarationExpression(
@@ -188,6 +220,9 @@ namespace iMobileDevice.Generator
             zeroProperty.Name = "Zero";
             zeroProperty.Attributes = MemberAttributes.Public | MemberAttributes.Static;
             zeroProperty.Type = new CodeTypeReference(safeHandle.Name);
+            zeroProperty.Comments.Add(new CodeCommentStatement(@"<summary>
+Gets a value which represents a pointer or handle that has been initialized to zero.
+</summary>"));
 
             zeroProperty.HasGet = true;
 
@@ -209,6 +244,7 @@ namespace iMobileDevice.Generator
             toStringMethod.Name = "ToString";
             toStringMethod.Attributes = MemberAttributes.Public | MemberAttributes.Override;
             toStringMethod.ReturnType = new CodeTypeReference(typeof(string));
+            toStringMethod.Comments.Add(new CodeCommentStatement("<inheritdoc/>"));
             toStringMethod.Statements.Add(
                 new CodeMethodReturnStatement(
                     new CodeMethodInvokeExpression(
@@ -231,6 +267,7 @@ namespace iMobileDevice.Generator
             equalsMethod.Name = "Equals";
             equalsMethod.Attributes = MemberAttributes.Public | MemberAttributes.Override;
             equalsMethod.ReturnType = new CodeTypeReference(typeof(bool));
+            equalsMethod.Comments.Add(new CodeCommentStatement("<inheritdoc/>"));
             equalsMethod.Parameters.Add(
                 new CodeParameterDeclarationExpression(
                     new CodeTypeReference(typeof(object)),
@@ -313,6 +350,7 @@ public static bool operator != ({safeHandle.Name} value1, {safeHandle.Name} valu
             getHashCodeMethod.Name = "GetHashCode";
             getHashCodeMethod.Attributes = MemberAttributes.Public | MemberAttributes.Override;
             getHashCodeMethod.ReturnType = new CodeTypeReference(typeof(int));
+            getHashCodeMethod.Comments.Add(new CodeCommentStatement("<inheritdoc/>"));
             getHashCodeMethod.Statements.Add(
                 new CodeMethodReturnStatement(
                     new CodeMethodInvokeExpression(

--- a/iMobileDevice.Generator/Handles.cs
+++ b/iMobileDevice.Generator/Handles.cs
@@ -272,6 +272,41 @@ namespace iMobileDevice.Generator
 
             safeHandle.Members.Add(equalsMethod);
 
+            // Override the operators
+            safeHandle.Members.Add(new CodeSnippetTypeMember($@"/// <summary>
+/// Determines whether two specified instances of <see cref=""{safeHandle.Name}""/> are equal.
+/// </summary>
+/// <param name=""value1"">
+/// The first pointer or handle to compare.
+/// </param>
+/// <param name=""value2"">
+/// The second pointer or handle to compare.
+/// </param>
+/// <returns>
+/// <see langword=""true""/> if <paramref name=""value1""/> equals <paramref name=""value2""/>; otherwise, <see langword=""false""/>.
+/// </returns>
+public static bool operator == ({safeHandle.Name} value1, {safeHandle.Name} value2) 
+{{
+    return value1.handle == value2.handle;
+}}"));
+
+            safeHandle.Members.Add(new CodeSnippetTypeMember($@"/// <summary>
+/// Determines whether two specified instances of <see cref=""{safeHandle.Name}""/> are not equal.
+/// </summary>
+/// <param name=""value1"">
+/// The first pointer or handle to compare.
+/// </param>
+/// <param name=""value2"">
+/// The second pointer or handle to compare.
+/// </param>
+/// <returns>
+/// <see langword=""true""/> if <paramref name=""value1""/> does not equal <paramref name=""value2""/>; otherwise, <see langword=""false""/>.
+/// </returns>
+public static bool operator != ({safeHandle.Name} value1, {safeHandle.Name} value2) 
+{{
+    return value1.handle != value2.handle;
+}}"));
+
             // Create the GetHashCode method
             // return this.handle.GetHashCode();
             CodeMemberMethod getHashCodeMethod = new CodeMemberMethod();


### PR DESCRIPTION
In the current implementation, `LockdownClientHandle.Zero == new LockdownClientHandle(IntPtr.Zero)` would return `false`. 

This PR adds the `==` and `!=` operators, and additional documentation for the various handle classes.