### PR TITLE
Don't load libraries on netstandard2.0, let the framework do it.

### DIFF
--- a/iMobileDevice-net/NativeLibraries.cs
+++ b/iMobileDevice-net/NativeLibraries.cs
@@ -17,7 +17,7 @@ namespace iMobileDevice
         /// </summary>
         public static bool LibraryFound
         {
-#if !NETSTANDARD1_5
+#if !NETSTANDARD1_5 && !NETSTANDARD2_0
             get;
             private set;
 #else
@@ -47,7 +47,7 @@ namespace iMobileDevice
         /// </param>
         public static void Load(string directory)
         {
-#if !NETSTANDARD1_5
+#if !NETSTANDARD1_5 && !NETSTANDARD2_0
             if (directory == null)
             {
                 throw new ArgumentNullException(nameof(directory));


### PR DESCRIPTION
We did lots of effort to load the native libraries on the .NET Framework. On .NET Core, just let the framework handle the loading for us.

Since we added support for `netstandard2.0`, we missed an `#if` statement which would disable loading on .NET Standard 2.0. This adds it back.