### PR TITLE
Fix null value handles in Handle operators

### DIFF
--- a/iMobileDevice-net/Afc/AfcClientHandle.cs
+++ b/iMobileDevice-net/Afc/AfcClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.Afc
         /// </returns>
         public static bool operator == (AfcClientHandle value1, AfcClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.Afc
         /// </returns>
         public static bool operator != (AfcClientHandle value1, AfcClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/DebugServer/DebugServerClientHandle.cs
+++ b/iMobileDevice-net/DebugServer/DebugServerClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.DebugServer
         /// </returns>
         public static bool operator == (DebugServerClientHandle value1, DebugServerClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.DebugServer
         /// </returns>
         public static bool operator != (DebugServerClientHandle value1, DebugServerClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/DebugServer/DebugServerCommandHandle.cs
+++ b/iMobileDevice-net/DebugServer/DebugServerCommandHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.DebugServer
         /// </returns>
         public static bool operator == (DebugServerCommandHandle value1, DebugServerCommandHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.DebugServer
         /// </returns>
         public static bool operator != (DebugServerCommandHandle value1, DebugServerCommandHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/DiagnosticsRelay/DiagnosticsRelayClientHandle.cs
+++ b/iMobileDevice-net/DiagnosticsRelay/DiagnosticsRelayClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.DiagnosticsRelay
         /// </returns>
         public static bool operator == (DiagnosticsRelayClientHandle value1, DiagnosticsRelayClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.DiagnosticsRelay
         /// </returns>
         public static bool operator != (DiagnosticsRelayClientHandle value1, DiagnosticsRelayClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/FileRelay/FileRelayClientHandle.cs
+++ b/iMobileDevice-net/FileRelay/FileRelayClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.FileRelay
         /// </returns>
         public static bool operator == (FileRelayClientHandle value1, FileRelayClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.FileRelay
         /// </returns>
         public static bool operator != (FileRelayClientHandle value1, FileRelayClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/HeartBeat/HeartBeatClientHandle.cs
+++ b/iMobileDevice-net/HeartBeat/HeartBeatClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.HeartBeat
         /// </returns>
         public static bool operator == (HeartBeatClientHandle value1, HeartBeatClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.HeartBeat
         /// </returns>
         public static bool operator != (HeartBeatClientHandle value1, HeartBeatClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/HouseArrest/HouseArrestClientHandle.cs
+++ b/iMobileDevice-net/HouseArrest/HouseArrestClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.HouseArrest
         /// </returns>
         public static bool operator == (HouseArrestClientHandle value1, HouseArrestClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.HouseArrest
         /// </returns>
         public static bool operator != (HouseArrestClientHandle value1, HouseArrestClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/InstallationProxy/InstallationProxyClientHandle.cs
+++ b/iMobileDevice-net/InstallationProxy/InstallationProxyClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.InstallationProxy
         /// </returns>
         public static bool operator == (InstallationProxyClientHandle value1, InstallationProxyClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.InstallationProxy
         /// </returns>
         public static bool operator != (InstallationProxyClientHandle value1, InstallationProxyClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/Lockdown/LockdownClientHandle.cs
+++ b/iMobileDevice-net/Lockdown/LockdownClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.Lockdown
         /// </returns>
         public static bool operator == (LockdownClientHandle value1, LockdownClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.Lockdown
         /// </returns>
         public static bool operator != (LockdownClientHandle value1, LockdownClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/Lockdown/LockdownPairRecordHandle.cs
+++ b/iMobileDevice-net/Lockdown/LockdownPairRecordHandle.cs
@@ -164,6 +164,16 @@ namespace iMobileDevice.Lockdown
         /// </returns>
         public static bool operator == (LockdownPairRecordHandle value1, LockdownPairRecordHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -181,6 +191,16 @@ namespace iMobileDevice.Lockdown
         /// </returns>
         public static bool operator != (LockdownPairRecordHandle value1, LockdownPairRecordHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/Lockdown/LockdownServiceDescriptorHandle.cs
+++ b/iMobileDevice-net/Lockdown/LockdownServiceDescriptorHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.Lockdown
         /// </returns>
         public static bool operator == (LockdownServiceDescriptorHandle value1, LockdownServiceDescriptorHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.Lockdown
         /// </returns>
         public static bool operator != (LockdownServiceDescriptorHandle value1, LockdownServiceDescriptorHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/Misagent/MisagentClientHandle.cs
+++ b/iMobileDevice-net/Misagent/MisagentClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.Misagent
         /// </returns>
         public static bool operator == (MisagentClientHandle value1, MisagentClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.Misagent
         /// </returns>
         public static bool operator != (MisagentClientHandle value1, MisagentClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/MobileBackup/MobileBackupClientHandle.cs
+++ b/iMobileDevice-net/MobileBackup/MobileBackupClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.MobileBackup
         /// </returns>
         public static bool operator == (MobileBackupClientHandle value1, MobileBackupClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.MobileBackup
         /// </returns>
         public static bool operator != (MobileBackupClientHandle value1, MobileBackupClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/MobileBackup2/MobileBackup2ClientHandle.cs
+++ b/iMobileDevice-net/MobileBackup2/MobileBackup2ClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.MobileBackup2
         /// </returns>
         public static bool operator == (MobileBackup2ClientHandle value1, MobileBackup2ClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.MobileBackup2
         /// </returns>
         public static bool operator != (MobileBackup2ClientHandle value1, MobileBackup2ClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/MobileImageMounter/MobileImageMounterClientHandle.cs
+++ b/iMobileDevice-net/MobileImageMounter/MobileImageMounterClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.MobileImageMounter
         /// </returns>
         public static bool operator == (MobileImageMounterClientHandle value1, MobileImageMounterClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.MobileImageMounter
         /// </returns>
         public static bool operator != (MobileImageMounterClientHandle value1, MobileImageMounterClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/MobileSync/MobileSyncAnchorsHandle.cs
+++ b/iMobileDevice-net/MobileSync/MobileSyncAnchorsHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.MobileSync
         /// </returns>
         public static bool operator == (MobileSyncAnchorsHandle value1, MobileSyncAnchorsHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.MobileSync
         /// </returns>
         public static bool operator != (MobileSyncAnchorsHandle value1, MobileSyncAnchorsHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/MobileSync/MobileSyncClientHandle.cs
+++ b/iMobileDevice-net/MobileSync/MobileSyncClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.MobileSync
         /// </returns>
         public static bool operator == (MobileSyncClientHandle value1, MobileSyncClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.MobileSync
         /// </returns>
         public static bool operator != (MobileSyncClientHandle value1, MobileSyncClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/Mobileactivation/MobileactivationClientHandle.cs
+++ b/iMobileDevice-net/Mobileactivation/MobileactivationClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.Mobileactivation
         /// </returns>
         public static bool operator == (MobileactivationClientHandle value1, MobileactivationClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.Mobileactivation
         /// </returns>
         public static bool operator != (MobileactivationClientHandle value1, MobileactivationClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/NotificationProxy/NotificationProxyClientHandle.cs
+++ b/iMobileDevice-net/NotificationProxy/NotificationProxyClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.NotificationProxy
         /// </returns>
         public static bool operator == (NotificationProxyClientHandle value1, NotificationProxyClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.NotificationProxy
         /// </returns>
         public static bool operator != (NotificationProxyClientHandle value1, NotificationProxyClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/Plist/PlistDictIterHandle.cs
+++ b/iMobileDevice-net/Plist/PlistDictIterHandle.cs
@@ -164,6 +164,16 @@ namespace iMobileDevice.Plist
         /// </returns>
         public static bool operator == (PlistDictIterHandle value1, PlistDictIterHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -181,6 +191,16 @@ namespace iMobileDevice.Plist
         /// </returns>
         public static bool operator != (PlistDictIterHandle value1, PlistDictIterHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/Plist/PlistHandle.cs
+++ b/iMobileDevice-net/Plist/PlistHandle.cs
@@ -166,6 +166,16 @@ namespace iMobileDevice.Plist
         /// </returns>
         public static bool operator == (PlistHandle value1, PlistHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -183,6 +193,16 @@ namespace iMobileDevice.Plist
         /// </returns>
         public static bool operator != (PlistHandle value1, PlistHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/PropertyListService/PropertyListServiceClientHandle.cs
+++ b/iMobileDevice-net/PropertyListService/PropertyListServiceClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.PropertyListService
         /// </returns>
         public static bool operator == (PropertyListServiceClientHandle value1, PropertyListServiceClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.PropertyListService
         /// </returns>
         public static bool operator != (PropertyListServiceClientHandle value1, PropertyListServiceClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/Restore/RestoreClientHandle.cs
+++ b/iMobileDevice-net/Restore/RestoreClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.Restore
         /// </returns>
         public static bool operator == (RestoreClientHandle value1, RestoreClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.Restore
         /// </returns>
         public static bool operator != (RestoreClientHandle value1, RestoreClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/Screenshotr/ScreenshotrClientHandle.cs
+++ b/iMobileDevice-net/Screenshotr/ScreenshotrClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.Screenshotr
         /// </returns>
         public static bool operator == (ScreenshotrClientHandle value1, ScreenshotrClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.Screenshotr
         /// </returns>
         public static bool operator != (ScreenshotrClientHandle value1, ScreenshotrClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/Service/ServiceClientHandle.cs
+++ b/iMobileDevice-net/Service/ServiceClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.Service
         /// </returns>
         public static bool operator == (ServiceClientHandle value1, ServiceClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.Service
         /// </returns>
         public static bool operator != (ServiceClientHandle value1, ServiceClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/SpringBoardServices/SpringBoardServicesClientHandle.cs
+++ b/iMobileDevice-net/SpringBoardServices/SpringBoardServicesClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.SpringBoardServices
         /// </returns>
         public static bool operator == (SpringBoardServicesClientHandle value1, SpringBoardServicesClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.SpringBoardServices
         /// </returns>
         public static bool operator != (SpringBoardServicesClientHandle value1, SpringBoardServicesClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/SyslogRelay/SyslogRelayClientHandle.cs
+++ b/iMobileDevice-net/SyslogRelay/SyslogRelayClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.SyslogRelay
         /// </returns>
         public static bool operator == (SyslogRelayClientHandle value1, SyslogRelayClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.SyslogRelay
         /// </returns>
         public static bool operator != (SyslogRelayClientHandle value1, SyslogRelayClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/WebInspector/WebInspectorClientHandle.cs
+++ b/iMobileDevice-net/WebInspector/WebInspectorClientHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.WebInspector
         /// </returns>
         public static bool operator == (WebInspectorClientHandle value1, WebInspectorClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.WebInspector
         /// </returns>
         public static bool operator != (WebInspectorClientHandle value1, WebInspectorClientHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/iDevice/iDeviceConnectionHandle.cs
+++ b/iMobileDevice-net/iDevice/iDeviceConnectionHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.iDevice
         /// </returns>
         public static bool operator == (iDeviceConnectionHandle value1, iDeviceConnectionHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.iDevice
         /// </returns>
         public static bool operator != (iDeviceConnectionHandle value1, iDeviceConnectionHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/iDevice/iDeviceHandle.cs
+++ b/iMobileDevice-net/iDevice/iDeviceHandle.cs
@@ -165,6 +165,16 @@ namespace iMobileDevice.iDevice
         /// </returns>
         public static bool operator == (iDeviceHandle value1, iDeviceHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -182,6 +192,16 @@ namespace iMobileDevice.iDevice
         /// </returns>
         public static bool operator != (iDeviceHandle value1, iDeviceHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationRequestHandle.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationRequestHandle.cs
@@ -166,6 +166,16 @@ namespace iMobileDevice.iDeviceActivation
         /// </returns>
         public static bool operator == (iDeviceActivationRequestHandle value1, iDeviceActivationRequestHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -183,6 +193,16 @@ namespace iMobileDevice.iDeviceActivation
         /// </returns>
         public static bool operator != (iDeviceActivationRequestHandle value1, iDeviceActivationRequestHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationResponseHandle.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationResponseHandle.cs
@@ -166,6 +166,16 @@ namespace iMobileDevice.iDeviceActivation
         /// </returns>
         public static bool operator == (iDeviceActivationResponseHandle value1, iDeviceActivationResponseHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle == value2.handle;
         }
         
@@ -183,6 +193,16 @@ namespace iMobileDevice.iDeviceActivation
         /// </returns>
         public static bool operator != (iDeviceActivationResponseHandle value1, iDeviceActivationResponseHandle value2) 
         {
+            if (value1 == null && value2 == null)
+            {
+                return false;
+            }
+        
+            if (value1 == null || value2 == null)
+            {
+                return false;
+            }
+        
             return value1.handle != value2.handle;
         }
     }

--- a/iMobileDevice.Generator/Handles.cs
+++ b/iMobileDevice.Generator/Handles.cs
@@ -324,6 +324,16 @@ Gets a value which represents a pointer or handle that has been initialized to z
 /// </returns>
 public static bool operator == ({safeHandle.Name} value1, {safeHandle.Name} value2) 
 {{
+    if (value1 == null && value2 == null)
+    {{
+        return true;
+    }}
+
+    if (value1 == null || value2 == null)
+    {{
+        return false;
+    }}
+
     return value1.handle == value2.handle;
 }}"));
 
@@ -341,6 +351,16 @@ public static bool operator == ({safeHandle.Name} value1, {safeHandle.Name} valu
 /// </returns>
 public static bool operator != ({safeHandle.Name} value1, {safeHandle.Name} value2) 
 {{
+    if (value1 == null && value2 == null)
+    {{
+        return false;
+    }}
+
+    if (value1 == null || value2 == null)
+    {{
+        return true;
+    }}
+
     return value1.handle != value2.handle;
 }}"));
 


### PR DESCRIPTION
The `==` and `!=` operators in the various `Handle` classes didn't handle `null` values very well. This PR fixes that.