### PR TITLE
Bring back native files for Ubuntu 16.04

### DIFF
--- a/download.cmd
+++ b/download.cmd
@@ -1,17 +1,30 @@
-set USBMUXD_VERSION=104
-set LIBIMOBILEDEVICE_VERSION=142
-set LIBIDEVICEACTIVATION_VERSION=18
+set USBMUXD_VERSION=131
+set LIBIMOBILEDEVICE_VERSION=168
+set LIBIDEVICEACTIVATION_VERSION=33
 
+REM download the archives
 wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/usbmuxd-osx-x64-1.1.0-%USBMUXD_VERSION%.tar.gz -O ext\usbmuxd-osx-x64-1.1.0-%USBMUXD_VERSION%.tar.gz
 wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/libimobiledevice-osx-x64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar.gz -O ext\libimobiledevice-osx-x64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar.gz
 wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/libideviceactivation-osx-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar.gz -O ext\libideviceactivation-osx-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar.gz
+
+wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/usbmuxd-linux-x64-1.1.0-%USBMUXD_VERSION%.tar.gz -O ext\usbmuxd-linux-x64-1.1.0-%USBMUXD_VERSION%.tar.gz
+wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/libimobiledevice-linux-x64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar.gz -O ext\libimobiledevice-linux-x64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar.gz
+wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/libideviceactivation-linux-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar.gz -O ext\libideviceactivation-linux-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar.gz
 
 REM extract tar file from tar.gz
 7z x -aos ext\usbmuxd-osx-x64-1.1.0-%USBMUXD_VERSION%.tar.gz -oext\
 7z x -aos ext\libimobiledevice-osx-x64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar.gz -oext\
 7z x -aos ext\libideviceactivation-osx-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar.gz -oext\
 
+7z x -aos ext\usbmuxd-linux-x64-1.1.0-%USBMUXD_VERSION%.tar.gz -oext\
+7z x -aos ext\libimobiledevice-linux-x64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar.gz -oext\
+7z x -aos ext\libideviceactivation-linux-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar.gz -oext\
+
 REM extract files from the tar files
 7z x -aos ext\usbmuxd-osx-x64-1.1.0-%USBMUXD_VERSION%.tar -oext\osx-x64
 7z x -aos ext\libimobiledevice-osx-x64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar -oext\osx-x64
 7z x -aos ext\libideviceactivation-osx-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar -oext\osx-x64
+
+7z x -aos ext\usbmuxd-linux-x64-1.1.0-%USBMUXD_VERSION%.tar -oext\osx-x64
+7z x -aos ext\libimobiledevice-linux-x64-1.2.1-%LIBIMOBILEDEVICE_VERSION%.tar -oext\linux-x64
+7z x -aos ext\libideviceactivation-linux-x64-1.0.0-%LIBIDEVICEACTIVATION_VERSION%.tar -oext\linux-x64

--- a/iMobileDevice-net/iMobileDevice-net.csproj
+++ b/iMobileDevice-net/iMobileDevice-net.csproj
@@ -54,7 +54,21 @@
     </Content>
     
     <!-- For Ubuntu Linux, we now recommend you use our PPA feed
-         https://launchpad.net/~quamotion/+archive/ubuntu/ppa -->
+         https://launchpad.net/~quamotion/+archive/ubuntu/ppa;
+         but we keep the Ubuntu 16.04 archives for backward compatibility
+         purposes. Starting with 18.04, you really need to use the PPAs, though :) -->
+    <Content Include="$(MSBuildThisFileDirectory)/../ext/linux-x64/lib/*.so">
+      <PackagePath>runtimes/ubuntu.16.04-x64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)/../ext/linux-x64/bin/*">
+      <PackagePath>runtimes/ubuntu.16.04-x64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)/../ext/linux-x64/sbin/*">
+      <PackagePath>runtimes/ubuntu.16.04-x64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
 
     <!-- macOS files come from the tarballs -->
     <Content Include="$(MSBuildThisFileDirectory)/../ext/osx-x64/lib/*.dylib">
@@ -81,6 +95,10 @@
     </Content>
     <Content Include="runtimes/osx-x64/native/*.*">
       <PackagePath>runtimes/osx-x64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="runtimes/debian-x64/native/*.*">
+      <PackagePath>runtimes/ubuntu.16.04-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
 


### PR DESCRIPTION
We shipped native files for debian-x64 in the past, although they are really only tested with Ubuntu 16.04. 

Removing them now is not very polite, so add them back.
To prevent issues (e.g. with the libcurl3->4 upgrade), scope them to Ubuntu 16.04 only.