### PR TITLE
Add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ obj
 ext
 *.suo
 *.user
+libclang.dll
 .vs
 packages
 *.opendb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: false
+sudo: true
 
 git:
   depth: false
@@ -9,31 +9,24 @@ mono: none
 dotnet: 2.1.400
 
 install:
+# Install libimobiledevice from the Quamotion PPA
+- sudo add-apt-repository -y ppa:quamotion/ppa
+- sudo apt-get update
+- sudo apt-get install -y libimobiledevice-dev libideviceactivation
+
 - mkdir ext
 - wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/usbmuxd-osx-x64-1.1.0-113.tar.gz -O ext/usbmuxd-osx-x64-1.1.0-113.tar.gz
-# - wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/usbmuxd-linux-arm-1.1.0-113.tar.gz -O ext/usbmuxd-linux-arm-1.1.0-113.tar.gz
-# - wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/usbmuxd-linux-arm64-1.1.0-113.tar.gz -O ext/usbmuxd-linux-arm64-1.1.0-113.tar.gz
 - wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/usbmuxd-linux-x64-1.1.0-113.tar.gz -O ext/usbmuxd-linux-x64-1.1.0-113.tar.gz
 - wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/libimobiledevice-osx-x64-1.2.1-146.tar.gz -O ext/libimobiledevice-osx-x64-1.2.1-146.tar.gz
-# - wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/libimobiledevice-linux-arm64-1.2.1-146.tar.gz -O ext/libimobiledevice-linux-arm64-1.2.1-146.tar.gz
-# - wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/libimobiledevice-linux-arm-1.2.1-146.tar.gz -O ext/libimobiledevice-linux-arm-1.2.1-146.tar.gz
 - wget -nc https://qmcdn.blob.core.windows.net/imobiledevice/libimobiledevice-linux-x64-1.2.1-146.tar.gz -O ext/libimobiledevice-linux-x64-1.2.1-146.tar.gz
 - tar -xvzf ext/usbmuxd-osx-x64-1.1.0-113.tar.gz -C ext
-# - tar -xvzf ext/usbmuxd-linux-arm-1.1.0-113.tar.gz -C ext
-# - tar -xvzf ext/usbmuxd-linux-arm64-1.1.0-113.tar.gz -C ext
 - tar -xvzf ext/usbmuxd-linux-x64-1.1.0-113.tar.gz -C ext
 - tar -xvzf ext/libimobiledevice-osx-x64-1.2.1-146.tar.gz -C ext
-# - tar -xvzf ext/libimobiledevice-linux-arm64-1.2.1-146.tar.gz -C ext
-# - tar -xvzf ext/libimobiledevice-linux-arm-1.2.1-146.tar.gz -C ext
 - tar -xvzf ext/libimobiledevice-linux-x64-1.2.1-146.tar.gz -C ext
 - dotnet restore iMobileDevice-net/iMobileDevice-net.csproj
-#- pip install --user azure-cli
 
 script:
 - dotnet build -c Release iMobileDevice-net/iMobileDevice-net.csproj
 - dotnet pack -c Release iMobileDevice-net/iMobileDevice-net.csproj
-
-after_success:
-#- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then az=$HOME/Library/Python/2.7/bin/az; fi
-#- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then az=$HOME/.local/bin/az; fi
-#- $az storage blob upload -f iMobileDevice-net/bin/Release/iMobileDevice-net.1.2.1-$TRAVIS_BUILD_NUMBER.nupkg -c imobiledevice -n iMobileDevice-net.1.2.1-$TRAVIS_BUILD_NUMBER.nupkg
+- dotnet test iMobileDevice.Generator.Tests/iMobileDevice.Generator.Tests.csproj
+- dotnet test iMobileDevice.Tests/iMobileDevice.Tests.csproj

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,13 @@ build_script:
   - 7z a -tzip libimobiledevice.1.2.1-r%APPVEYOR_BUILD_NUMBER%-win-x86.zip .\zip\runtimes\win-x86\native\*
   - 7z a -tzip libimobiledevice.1.2.1-r%APPVEYOR_BUILD_NUMBER%-win-x64.zip .\zip\runtimes\win-x64\native\*
 
+  # This should help the tests locate libimobiledevice and friends
+  - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%\zip\runtimes\win-x64\native
+  - echo %PATH%
+  - dir %APPVEYOR_BUILD_FOLDER%\zip\runtimes\win-x64\native
+  - dotnet test iMobileDevice.Generator.Tests\iMobileDevice.Generator.Tests.csproj
+  - dotnet test iMobileDevice.Tests\iMobileDevice.Tests.csproj
+
 artifacts:
   - path: imobiledevice-net\bin\Release\imobiledevice-net.*.nupkg
     name: imobiledevice-net

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ cache:
 
 build_script:
   - cd iMobileDevice.Generator
-  - dotnet run --no-restore iMobileDevice.Generator.csproj . ..\iMobileDevice-net
+  - dotnet run . ..\iMobileDevice-net
   - cd ..
   - dotnet build imobiledevice-net\iMobileDevice-net.csproj
   - dotnet pack imobiledevice-net\iMobileDevice-net.csproj -c Release

--- a/iMobileDevice-net/Afc/AfcClientHandle.cs
+++ b/iMobileDevice-net/Afc/AfcClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="AfcClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.Afc
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class AfcClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for Afc handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class AfcClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AfcClientHandle"/> class.
         /// </summary>
-        protected AfcClientHandle() : 
+        protected AfcClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AfcClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected AfcClientHandle(bool ownsHandle) : 
+        protected AfcClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.Afc
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.Afc
                 return AfcClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.Afc.afc_client_free(this.handle) == AfcError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.Afc
         /// </returns>
         public static AfcClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            AfcClientHandle safeHandle;
-            safeHandle = new AfcClientHandle(ownsHandle);
+            AfcClientHandle safeHandle = new AfcClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.Afc
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(AfcClientHandle))))
+            if (obj != null && obj.GetType() == typeof(AfcClientHandle))
             {
                 return ((AfcClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/DebugServer/DebugServerClientHandle.cs
+++ b/iMobileDevice-net/DebugServer/DebugServerClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="DebugServerClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.DebugServer
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class DebugServerClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for DebugServer handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class DebugServerClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DebugServerClientHandle"/> class.
         /// </summary>
-        protected DebugServerClientHandle() : 
+        protected DebugServerClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DebugServerClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected DebugServerClientHandle(bool ownsHandle) : 
+        protected DebugServerClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.DebugServer
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.DebugServer
                 return DebugServerClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.DebugServer.debugserver_client_free(this.handle) == DebugServerError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.DebugServer
         /// </returns>
         public static DebugServerClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            DebugServerClientHandle safeHandle;
-            safeHandle = new DebugServerClientHandle(ownsHandle);
+            DebugServerClientHandle safeHandle = new DebugServerClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.DebugServer
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(DebugServerClientHandle))))
+            if (obj != null && obj.GetType() == typeof(DebugServerClientHandle))
             {
                 return ((DebugServerClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/DebugServer/DebugServerCommandHandle.cs
+++ b/iMobileDevice-net/DebugServer/DebugServerCommandHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="DebugServerCommandHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.DebugServer
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class DebugServerCommandHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for DebugServer handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class DebugServerCommandHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DebugServerCommandHandle"/> class.
         /// </summary>
-        protected DebugServerCommandHandle() : 
+        protected DebugServerCommandHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DebugServerCommandHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected DebugServerCommandHandle(bool ownsHandle) : 
+        protected DebugServerCommandHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.DebugServer
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.DebugServer
                 return DebugServerCommandHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.DebugServer.debugserver_command_free(this.handle) == DebugServerError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.DebugServer
         /// </returns>
         public static DebugServerCommandHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            DebugServerCommandHandle safeHandle;
-            safeHandle = new DebugServerCommandHandle(ownsHandle);
+            DebugServerCommandHandle safeHandle = new DebugServerCommandHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.DebugServer
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(DebugServerCommandHandle))))
+            if (obj != null && obj.GetType() == typeof(DebugServerCommandHandle))
             {
                 return ((DebugServerCommandHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/DiagnosticsRelay/DiagnosticsRelayClientHandle.cs
+++ b/iMobileDevice-net/DiagnosticsRelay/DiagnosticsRelayClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="DiagnosticsRelayClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.DiagnosticsRelay
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class DiagnosticsRelayClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for DiagnosticsRelay handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class DiagnosticsRelayClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DiagnosticsRelayClientHandle"/> class.
         /// </summary>
-        protected DiagnosticsRelayClientHandle() : 
+        protected DiagnosticsRelayClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DiagnosticsRelayClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected DiagnosticsRelayClientHandle(bool ownsHandle) : 
+        protected DiagnosticsRelayClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.DiagnosticsRelay
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.DiagnosticsRelay
                 return DiagnosticsRelayClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.DiagnosticsRelay.diagnostics_relay_client_free(this.handle) == DiagnosticsRelayError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.DiagnosticsRelay
         /// </returns>
         public static DiagnosticsRelayClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            DiagnosticsRelayClientHandle safeHandle;
-            safeHandle = new DiagnosticsRelayClientHandle(ownsHandle);
+            DiagnosticsRelayClientHandle safeHandle = new DiagnosticsRelayClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.DiagnosticsRelay
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(DiagnosticsRelayClientHandle))))
+            if (obj != null && obj.GetType() == typeof(DiagnosticsRelayClientHandle))
             {
                 return ((DiagnosticsRelayClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/FileRelay/FileRelayClientHandle.cs
+++ b/iMobileDevice-net/FileRelay/FileRelayClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="FileRelayClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.FileRelay
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class FileRelayClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for FileRelay handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class FileRelayClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="FileRelayClientHandle"/> class.
         /// </summary>
-        protected FileRelayClientHandle() : 
+        protected FileRelayClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="FileRelayClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected FileRelayClientHandle(bool ownsHandle) : 
+        protected FileRelayClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.FileRelay
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.FileRelay
                 return FileRelayClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.FileRelay.file_relay_client_free(this.handle) == FileRelayError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.FileRelay
         /// </returns>
         public static FileRelayClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            FileRelayClientHandle safeHandle;
-            safeHandle = new FileRelayClientHandle(ownsHandle);
+            FileRelayClientHandle safeHandle = new FileRelayClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.FileRelay
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(FileRelayClientHandle))))
+            if (obj != null && obj.GetType() == typeof(FileRelayClientHandle))
             {
                 return ((FileRelayClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/HeartBeat/HeartBeatClientHandle.cs
+++ b/iMobileDevice-net/HeartBeat/HeartBeatClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="HeartBeatClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.HeartBeat
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class HeartBeatClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for HeartBeat handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class HeartBeatClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="HeartBeatClientHandle"/> class.
         /// </summary>
-        protected HeartBeatClientHandle() : 
+        protected HeartBeatClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="HeartBeatClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected HeartBeatClientHandle(bool ownsHandle) : 
+        protected HeartBeatClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.HeartBeat
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.HeartBeat
                 return HeartBeatClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.HeartBeat.heartbeat_client_free(this.handle) == HeartBeatError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.HeartBeat
         /// </returns>
         public static HeartBeatClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            HeartBeatClientHandle safeHandle;
-            safeHandle = new HeartBeatClientHandle(ownsHandle);
+            HeartBeatClientHandle safeHandle = new HeartBeatClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.HeartBeat
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(HeartBeatClientHandle))))
+            if (obj != null && obj.GetType() == typeof(HeartBeatClientHandle))
             {
                 return ((HeartBeatClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/HouseArrest/HouseArrestClientHandle.cs
+++ b/iMobileDevice-net/HouseArrest/HouseArrestClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="HouseArrestClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.HouseArrest
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class HouseArrestClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for HouseArrest handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class HouseArrestClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="HouseArrestClientHandle"/> class.
         /// </summary>
-        protected HouseArrestClientHandle() : 
+        protected HouseArrestClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="HouseArrestClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected HouseArrestClientHandle(bool ownsHandle) : 
+        protected HouseArrestClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.HouseArrest
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.HouseArrest
                 return HouseArrestClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.HouseArrest.house_arrest_client_free(this.handle) == HouseArrestError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.HouseArrest
         /// </returns>
         public static HouseArrestClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            HouseArrestClientHandle safeHandle;
-            safeHandle = new HouseArrestClientHandle(ownsHandle);
+            HouseArrestClientHandle safeHandle = new HouseArrestClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.HouseArrest
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(HouseArrestClientHandle))))
+            if (obj != null && obj.GetType() == typeof(HouseArrestClientHandle))
             {
                 return ((HouseArrestClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/InstallationProxy/InstallationProxyApi.cs
+++ b/iMobileDevice-net/InstallationProxy/InstallationProxyApi.cs
@@ -577,6 +577,7 @@ namespace iMobileDevice.InstallationProxy
         public virtual void instproxy_status_get_current_list(PlistHandle status, ref ulong total, ref ulong currentIndex, ref ulong currentAmount, out PlistHandle list)
         {
             InstallationProxyNativeMethods.instproxy_status_get_current_list(status, ref total, ref currentIndex, ref currentAmount, out list);
+            list.Api = this.Parent;
         }
         
         /// <summary>

--- a/iMobileDevice-net/InstallationProxy/InstallationProxyClientHandle.cs
+++ b/iMobileDevice-net/InstallationProxy/InstallationProxyClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="InstallationProxyClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.InstallationProxy
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class InstallationProxyClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for InstallationProxy handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class InstallationProxyClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="InstallationProxyClientHandle"/> class.
         /// </summary>
-        protected InstallationProxyClientHandle() : 
+        protected InstallationProxyClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="InstallationProxyClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected InstallationProxyClientHandle(bool ownsHandle) : 
+        protected InstallationProxyClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.InstallationProxy
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.InstallationProxy
                 return InstallationProxyClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.InstallationProxy.instproxy_client_free(this.handle) == InstallationProxyError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.InstallationProxy
         /// </returns>
         public static InstallationProxyClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            InstallationProxyClientHandle safeHandle;
-            safeHandle = new InstallationProxyClientHandle(ownsHandle);
+            InstallationProxyClientHandle safeHandle = new InstallationProxyClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.InstallationProxy
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(InstallationProxyClientHandle))))
+            if (obj != null && obj.GetType() == typeof(InstallationProxyClientHandle))
             {
                 return ((InstallationProxyClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/Lockdown/LockdownClientHandle.cs
+++ b/iMobileDevice-net/Lockdown/LockdownClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="LockdownClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.Lockdown
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class LockdownClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for Lockdown handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class LockdownClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="LockdownClientHandle"/> class.
         /// </summary>
-        protected LockdownClientHandle() : 
+        protected LockdownClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="LockdownClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected LockdownClientHandle(bool ownsHandle) : 
+        protected LockdownClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.Lockdown
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.Lockdown
                 return LockdownClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.Lockdown.lockdownd_client_free(this.handle) == LockdownError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.Lockdown
         /// </returns>
         public static LockdownClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            LockdownClientHandle safeHandle;
-            safeHandle = new LockdownClientHandle(ownsHandle);
+            LockdownClientHandle safeHandle = new LockdownClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.Lockdown
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(LockdownClientHandle))))
+            if (obj != null && obj.GetType() == typeof(LockdownClientHandle))
             {
                 return ((LockdownClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/Lockdown/LockdownPairRecordHandle.cs
+++ b/iMobileDevice-net/Lockdown/LockdownPairRecordHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="LockdownPairRecordHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.Lockdown
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class LockdownPairRecordHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for Lockdown handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class LockdownPairRecordHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="LockdownPairRecordHandle"/> class.
         /// </summary>
-        protected LockdownPairRecordHandle() : 
+        protected LockdownPairRecordHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="LockdownPairRecordHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected LockdownPairRecordHandle(bool ownsHandle) : 
+        protected LockdownPairRecordHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.Lockdown
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,11 +77,9 @@ namespace iMobileDevice.Lockdown
                 return LockdownPairRecordHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             return true;
@@ -106,8 +98,7 @@ namespace iMobileDevice.Lockdown
         /// </returns>
         public static LockdownPairRecordHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            LockdownPairRecordHandle safeHandle;
-            safeHandle = new LockdownPairRecordHandle(ownsHandle);
+            LockdownPairRecordHandle safeHandle = new LockdownPairRecordHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -134,7 +125,7 @@ namespace iMobileDevice.Lockdown
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(LockdownPairRecordHandle))))
+            if (obj != null && obj.GetType() == typeof(LockdownPairRecordHandle))
             {
                 return ((LockdownPairRecordHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/Lockdown/LockdownServiceDescriptorHandle.cs
+++ b/iMobileDevice-net/Lockdown/LockdownServiceDescriptorHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="LockdownServiceDescriptorHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.Lockdown
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class LockdownServiceDescriptorHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for Lockdown handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class LockdownServiceDescriptorHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="LockdownServiceDescriptorHandle"/> class.
         /// </summary>
-        protected LockdownServiceDescriptorHandle() : 
+        protected LockdownServiceDescriptorHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="LockdownServiceDescriptorHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected LockdownServiceDescriptorHandle(bool ownsHandle) : 
+        protected LockdownServiceDescriptorHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.Lockdown
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.Lockdown
                 return LockdownServiceDescriptorHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.Lockdown.lockdownd_service_descriptor_free(this.handle) == LockdownError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.Lockdown
         /// </returns>
         public static LockdownServiceDescriptorHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            LockdownServiceDescriptorHandle safeHandle;
-            safeHandle = new LockdownServiceDescriptorHandle(ownsHandle);
+            LockdownServiceDescriptorHandle safeHandle = new LockdownServiceDescriptorHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.Lockdown
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(LockdownServiceDescriptorHandle))))
+            if (obj != null && obj.GetType() == typeof(LockdownServiceDescriptorHandle))
             {
                 return ((LockdownServiceDescriptorHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/Misagent/MisagentClientHandle.cs
+++ b/iMobileDevice-net/Misagent/MisagentClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="MisagentClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.Misagent
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class MisagentClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for Misagent handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class MisagentClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MisagentClientHandle"/> class.
         /// </summary>
-        protected MisagentClientHandle() : 
+        protected MisagentClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MisagentClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected MisagentClientHandle(bool ownsHandle) : 
+        protected MisagentClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.Misagent
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.Misagent
                 return MisagentClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.Misagent.misagent_client_free(this.handle) == MisagentError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.Misagent
         /// </returns>
         public static MisagentClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            MisagentClientHandle safeHandle;
-            safeHandle = new MisagentClientHandle(ownsHandle);
+            MisagentClientHandle safeHandle = new MisagentClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.Misagent
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(MisagentClientHandle))))
+            if (obj != null && obj.GetType() == typeof(MisagentClientHandle))
             {
                 return ((MisagentClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/MobileBackup/MobileBackupClientHandle.cs
+++ b/iMobileDevice-net/MobileBackup/MobileBackupClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="MobileBackupClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.MobileBackup
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class MobileBackupClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for MobileBackup handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class MobileBackupClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MobileBackupClientHandle"/> class.
         /// </summary>
-        protected MobileBackupClientHandle() : 
+        protected MobileBackupClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MobileBackupClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected MobileBackupClientHandle(bool ownsHandle) : 
+        protected MobileBackupClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.MobileBackup
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.MobileBackup
                 return MobileBackupClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.MobileBackup.mobilebackup_client_free(this.handle) == MobileBackupError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.MobileBackup
         /// </returns>
         public static MobileBackupClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            MobileBackupClientHandle safeHandle;
-            safeHandle = new MobileBackupClientHandle(ownsHandle);
+            MobileBackupClientHandle safeHandle = new MobileBackupClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.MobileBackup
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(MobileBackupClientHandle))))
+            if (obj != null && obj.GetType() == typeof(MobileBackupClientHandle))
             {
                 return ((MobileBackupClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/MobileBackup2/MobileBackup2ClientHandle.cs
+++ b/iMobileDevice-net/MobileBackup2/MobileBackup2ClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="MobileBackup2ClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.MobileBackup2
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class MobileBackup2ClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for MobileBackup2 handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class MobileBackup2ClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MobileBackup2ClientHandle"/> class.
         /// </summary>
-        protected MobileBackup2ClientHandle() : 
+        protected MobileBackup2ClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MobileBackup2ClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected MobileBackup2ClientHandle(bool ownsHandle) : 
+        protected MobileBackup2ClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.MobileBackup2
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.MobileBackup2
                 return MobileBackup2ClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.MobileBackup2.mobilebackup2_client_free(this.handle) == MobileBackup2Error.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.MobileBackup2
         /// </returns>
         public static MobileBackup2ClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            MobileBackup2ClientHandle safeHandle;
-            safeHandle = new MobileBackup2ClientHandle(ownsHandle);
+            MobileBackup2ClientHandle safeHandle = new MobileBackup2ClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.MobileBackup2
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(MobileBackup2ClientHandle))))
+            if (obj != null && obj.GetType() == typeof(MobileBackup2ClientHandle))
             {
                 return ((MobileBackup2ClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/MobileImageMounter/MobileImageMounterClientHandle.cs
+++ b/iMobileDevice-net/MobileImageMounter/MobileImageMounterClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="MobileImageMounterClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.MobileImageMounter
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class MobileImageMounterClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for MobileImageMounter handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class MobileImageMounterClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MobileImageMounterClientHandle"/> class.
         /// </summary>
-        protected MobileImageMounterClientHandle() : 
+        protected MobileImageMounterClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MobileImageMounterClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected MobileImageMounterClientHandle(bool ownsHandle) : 
+        protected MobileImageMounterClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.MobileImageMounter
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.MobileImageMounter
                 return MobileImageMounterClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.MobileImageMounter.mobile_image_mounter_free(this.handle) == MobileImageMounterError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.MobileImageMounter
         /// </returns>
         public static MobileImageMounterClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            MobileImageMounterClientHandle safeHandle;
-            safeHandle = new MobileImageMounterClientHandle(ownsHandle);
+            MobileImageMounterClientHandle safeHandle = new MobileImageMounterClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.MobileImageMounter
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(MobileImageMounterClientHandle))))
+            if (obj != null && obj.GetType() == typeof(MobileImageMounterClientHandle))
             {
                 return ((MobileImageMounterClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/MobileSync/MobileSyncAnchorsHandle.cs
+++ b/iMobileDevice-net/MobileSync/MobileSyncAnchorsHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="MobileSyncAnchorsHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.MobileSync
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class MobileSyncAnchorsHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for MobileSync handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class MobileSyncAnchorsHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MobileSyncAnchorsHandle"/> class.
         /// </summary>
-        protected MobileSyncAnchorsHandle() : 
+        protected MobileSyncAnchorsHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MobileSyncAnchorsHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected MobileSyncAnchorsHandle(bool ownsHandle) : 
+        protected MobileSyncAnchorsHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.MobileSync
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.MobileSync
                 return MobileSyncAnchorsHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.MobileSync.mobilesync_anchors_free(this.handle) == MobileSyncError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.MobileSync
         /// </returns>
         public static MobileSyncAnchorsHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            MobileSyncAnchorsHandle safeHandle;
-            safeHandle = new MobileSyncAnchorsHandle(ownsHandle);
+            MobileSyncAnchorsHandle safeHandle = new MobileSyncAnchorsHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.MobileSync
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(MobileSyncAnchorsHandle))))
+            if (obj != null && obj.GetType() == typeof(MobileSyncAnchorsHandle))
             {
                 return ((MobileSyncAnchorsHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/MobileSync/MobileSyncClientHandle.cs
+++ b/iMobileDevice-net/MobileSync/MobileSyncClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="MobileSyncClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.MobileSync
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class MobileSyncClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for MobileSync handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class MobileSyncClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MobileSyncClientHandle"/> class.
         /// </summary>
-        protected MobileSyncClientHandle() : 
+        protected MobileSyncClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MobileSyncClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected MobileSyncClientHandle(bool ownsHandle) : 
+        protected MobileSyncClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.MobileSync
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.MobileSync
                 return MobileSyncClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.MobileSync.mobilesync_client_free(this.handle) == MobileSyncError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.MobileSync
         /// </returns>
         public static MobileSyncClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            MobileSyncClientHandle safeHandle;
-            safeHandle = new MobileSyncClientHandle(ownsHandle);
+            MobileSyncClientHandle safeHandle = new MobileSyncClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.MobileSync
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(MobileSyncClientHandle))))
+            if (obj != null && obj.GetType() == typeof(MobileSyncClientHandle))
             {
                 return ((MobileSyncClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/Mobileactivation/MobileactivationClientHandle.cs
+++ b/iMobileDevice-net/Mobileactivation/MobileactivationClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="MobileactivationClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.Mobileactivation
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class MobileactivationClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for Mobileactivation handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class MobileactivationClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MobileactivationClientHandle"/> class.
         /// </summary>
-        protected MobileactivationClientHandle() : 
+        protected MobileactivationClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MobileactivationClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected MobileactivationClientHandle(bool ownsHandle) : 
+        protected MobileactivationClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.Mobileactivation
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.Mobileactivation
                 return MobileactivationClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.Mobileactivation.mobileactivation_client_free(this.handle) == MobileactivationError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.Mobileactivation
         /// </returns>
         public static MobileactivationClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            MobileactivationClientHandle safeHandle;
-            safeHandle = new MobileactivationClientHandle(ownsHandle);
+            MobileactivationClientHandle safeHandle = new MobileactivationClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.Mobileactivation
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(MobileactivationClientHandle))))
+            if (obj != null && obj.GetType() == typeof(MobileactivationClientHandle))
             {
                 return ((MobileactivationClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/NotificationProxy/NotificationProxyClientHandle.cs
+++ b/iMobileDevice-net/NotificationProxy/NotificationProxyClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="NotificationProxyClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.NotificationProxy
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class NotificationProxyClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for NotificationProxy handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class NotificationProxyClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationProxyClientHandle"/> class.
         /// </summary>
-        protected NotificationProxyClientHandle() : 
+        protected NotificationProxyClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationProxyClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected NotificationProxyClientHandle(bool ownsHandle) : 
+        protected NotificationProxyClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.NotificationProxy
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.NotificationProxy
                 return NotificationProxyClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.NotificationProxy.np_client_free(this.handle) == NotificationProxyError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.NotificationProxy
         /// </returns>
         public static NotificationProxyClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            NotificationProxyClientHandle safeHandle;
-            safeHandle = new NotificationProxyClientHandle(ownsHandle);
+            NotificationProxyClientHandle safeHandle = new NotificationProxyClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.NotificationProxy
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(NotificationProxyClientHandle))))
+            if (obj != null && obj.GetType() == typeof(NotificationProxyClientHandle))
             {
                 return ((NotificationProxyClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/Plist/PlistApi.cs
+++ b/iMobileDevice-net/Plist/PlistApi.cs
@@ -374,6 +374,7 @@ namespace iMobileDevice.Plist
         public virtual void plist_dict_new_iter(PlistHandle node, out PlistDictIterHandle iter)
         {
             PlistNativeMethods.plist_dict_new_iter(node, out iter);
+            iter.Api = this.Parent;
         }
         
         /// <summary>
@@ -396,6 +397,7 @@ namespace iMobileDevice.Plist
         public virtual void plist_dict_next_item(PlistHandle node, PlistDictIterHandle iter, out string key, out PlistHandle val)
         {
             PlistNativeMethods.plist_dict_next_item(node, iter, out key, out val);
+            val.Api = this.Parent;
         }
         
         /// <summary>
@@ -500,6 +502,7 @@ namespace iMobileDevice.Plist
         public virtual void plist_dict_merge(out PlistHandle target, PlistHandle source)
         {
             PlistNativeMethods.plist_dict_merge(out target, source);
+            target.Api = this.Parent;
         }
         
         /// <summary>
@@ -860,6 +863,7 @@ namespace iMobileDevice.Plist
         public virtual void plist_from_xml(string plistXml, uint length, out PlistHandle plist)
         {
             PlistNativeMethods.plist_from_xml(plistXml, length, out plist);
+            plist.Api = this.Parent;
         }
         
         /// <summary>
@@ -877,6 +881,7 @@ namespace iMobileDevice.Plist
         public virtual void plist_from_bin(string plistBin, uint length, out PlistHandle plist)
         {
             PlistNativeMethods.plist_from_bin(plistBin, length, out plist);
+            plist.Api = this.Parent;
         }
         
         /// <summary>
@@ -896,6 +901,7 @@ namespace iMobileDevice.Plist
         public virtual void plist_from_memory(string plistData, uint length, out PlistHandle plist)
         {
             PlistNativeMethods.plist_from_memory(plistData, length, out plist);
+            plist.Api = this.Parent;
         }
         
         /// <summary>

--- a/iMobileDevice-net/Plist/PlistDictIterHandle.cs
+++ b/iMobileDevice-net/Plist/PlistDictIterHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="PlistDictIterHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.Plist
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class PlistDictIterHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for Plist handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class PlistDictIterHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PlistDictIterHandle"/> class.
         /// </summary>
-        protected PlistDictIterHandle() : 
+        protected PlistDictIterHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PlistDictIterHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected PlistDictIterHandle(bool ownsHandle) : 
+        protected PlistDictIterHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.Plist
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,11 +77,9 @@ namespace iMobileDevice.Plist
                 return PlistDictIterHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             return true;
@@ -106,8 +98,7 @@ namespace iMobileDevice.Plist
         /// </returns>
         public static PlistDictIterHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            PlistDictIterHandle safeHandle;
-            safeHandle = new PlistDictIterHandle(ownsHandle);
+            PlistDictIterHandle safeHandle = new PlistDictIterHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -134,7 +125,7 @@ namespace iMobileDevice.Plist
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(PlistDictIterHandle))))
+            if (obj != null && obj.GetType() == typeof(PlistDictIterHandle))
             {
                 return ((PlistDictIterHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/Plist/PlistHandle.cs
+++ b/iMobileDevice-net/Plist/PlistHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="PlistHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.Plist
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class PlistHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for Plist handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class PlistHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PlistHandle"/> class.
         /// </summary>
-        protected PlistHandle() : 
+        protected PlistHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PlistHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected PlistHandle(bool ownsHandle) : 
+        protected PlistHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.Plist
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.Plist
                 return PlistHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             this.Api.Plist.plist_free(this.handle);
             return true;
         }
@@ -108,8 +101,7 @@ namespace iMobileDevice.Plist
         /// </returns>
         public static PlistHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            PlistHandle safeHandle;
-            safeHandle = new PlistHandle(ownsHandle);
+            PlistHandle safeHandle = new PlistHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -136,7 +128,7 @@ namespace iMobileDevice.Plist
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(PlistHandle))))
+            if (obj != null && obj.GetType() == typeof(PlistHandle))
             {
                 return ((PlistHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/PropertyListService/PropertyListServiceClientHandle.cs
+++ b/iMobileDevice-net/PropertyListService/PropertyListServiceClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="PropertyListServiceClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.PropertyListService
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class PropertyListServiceClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for PropertyListService handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class PropertyListServiceClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertyListServiceClientHandle"/> class.
         /// </summary>
-        protected PropertyListServiceClientHandle() : 
+        protected PropertyListServiceClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertyListServiceClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected PropertyListServiceClientHandle(bool ownsHandle) : 
+        protected PropertyListServiceClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.PropertyListService
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.PropertyListService
                 return PropertyListServiceClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.PropertyListService.property_list_service_client_free(this.handle) == PropertyListServiceError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.PropertyListService
         /// </returns>
         public static PropertyListServiceClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            PropertyListServiceClientHandle safeHandle;
-            safeHandle = new PropertyListServiceClientHandle(ownsHandle);
+            PropertyListServiceClientHandle safeHandle = new PropertyListServiceClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.PropertyListService
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(PropertyListServiceClientHandle))))
+            if (obj != null && obj.GetType() == typeof(PropertyListServiceClientHandle))
             {
                 return ((PropertyListServiceClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/Restore/RestoreClientHandle.cs
+++ b/iMobileDevice-net/Restore/RestoreClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="RestoreClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.Restore
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class RestoreClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for Restore handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class RestoreClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RestoreClientHandle"/> class.
         /// </summary>
-        protected RestoreClientHandle() : 
+        protected RestoreClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RestoreClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected RestoreClientHandle(bool ownsHandle) : 
+        protected RestoreClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.Restore
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.Restore
                 return RestoreClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.Restore.restored_client_free(this.handle) == RestoreError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.Restore
         /// </returns>
         public static RestoreClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            RestoreClientHandle safeHandle;
-            safeHandle = new RestoreClientHandle(ownsHandle);
+            RestoreClientHandle safeHandle = new RestoreClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.Restore
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(RestoreClientHandle))))
+            if (obj != null && obj.GetType() == typeof(RestoreClientHandle))
             {
                 return ((RestoreClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/Screenshotr/ScreenshotrClientHandle.cs
+++ b/iMobileDevice-net/Screenshotr/ScreenshotrClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="ScreenshotrClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.Screenshotr
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class ScreenshotrClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for Screenshotr handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class ScreenshotrClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ScreenshotrClientHandle"/> class.
         /// </summary>
-        protected ScreenshotrClientHandle() : 
+        protected ScreenshotrClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ScreenshotrClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected ScreenshotrClientHandle(bool ownsHandle) : 
+        protected ScreenshotrClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.Screenshotr
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.Screenshotr
                 return ScreenshotrClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.Screenshotr.screenshotr_client_free(this.handle) == ScreenshotrError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.Screenshotr
         /// </returns>
         public static ScreenshotrClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            ScreenshotrClientHandle safeHandle;
-            safeHandle = new ScreenshotrClientHandle(ownsHandle);
+            ScreenshotrClientHandle safeHandle = new ScreenshotrClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.Screenshotr
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(ScreenshotrClientHandle))))
+            if (obj != null && obj.GetType() == typeof(ScreenshotrClientHandle))
             {
                 return ((ScreenshotrClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/Service/ServiceClientHandle.cs
+++ b/iMobileDevice-net/Service/ServiceClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="ServiceClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.Service
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class ServiceClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for Service handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class ServiceClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceClientHandle"/> class.
         /// </summary>
-        protected ServiceClientHandle() : 
+        protected ServiceClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected ServiceClientHandle(bool ownsHandle) : 
+        protected ServiceClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.Service
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.Service
                 return ServiceClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.Service.service_client_free(this.handle) == ServiceError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.Service
         /// </returns>
         public static ServiceClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            ServiceClientHandle safeHandle;
-            safeHandle = new ServiceClientHandle(ownsHandle);
+            ServiceClientHandle safeHandle = new ServiceClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.Service
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(ServiceClientHandle))))
+            if (obj != null && obj.GetType() == typeof(ServiceClientHandle))
             {
                 return ((ServiceClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/SpringBoardServices/SpringBoardServicesClientHandle.cs
+++ b/iMobileDevice-net/SpringBoardServices/SpringBoardServicesClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="SpringBoardServicesClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.SpringBoardServices
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class SpringBoardServicesClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for SpringBoardServices handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class SpringBoardServicesClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SpringBoardServicesClientHandle"/> class.
         /// </summary>
-        protected SpringBoardServicesClientHandle() : 
+        protected SpringBoardServicesClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SpringBoardServicesClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected SpringBoardServicesClientHandle(bool ownsHandle) : 
+        protected SpringBoardServicesClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.SpringBoardServices
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.SpringBoardServices
                 return SpringBoardServicesClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.SpringBoardServices.sbservices_client_free(this.handle) == SpringBoardServicesError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.SpringBoardServices
         /// </returns>
         public static SpringBoardServicesClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            SpringBoardServicesClientHandle safeHandle;
-            safeHandle = new SpringBoardServicesClientHandle(ownsHandle);
+            SpringBoardServicesClientHandle safeHandle = new SpringBoardServicesClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.SpringBoardServices
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(SpringBoardServicesClientHandle))))
+            if (obj != null && obj.GetType() == typeof(SpringBoardServicesClientHandle))
             {
                 return ((SpringBoardServicesClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/SyslogRelay/SyslogRelayClientHandle.cs
+++ b/iMobileDevice-net/SyslogRelay/SyslogRelayClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="SyslogRelayClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.SyslogRelay
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class SyslogRelayClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for SyslogRelay handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class SyslogRelayClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SyslogRelayClientHandle"/> class.
         /// </summary>
-        protected SyslogRelayClientHandle() : 
+        protected SyslogRelayClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SyslogRelayClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected SyslogRelayClientHandle(bool ownsHandle) : 
+        protected SyslogRelayClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.SyslogRelay
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.SyslogRelay
                 return SyslogRelayClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.SyslogRelay.syslog_relay_client_free(this.handle) == SyslogRelayError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.SyslogRelay
         /// </returns>
         public static SyslogRelayClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            SyslogRelayClientHandle safeHandle;
-            safeHandle = new SyslogRelayClientHandle(ownsHandle);
+            SyslogRelayClientHandle safeHandle = new SyslogRelayClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.SyslogRelay
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(SyslogRelayClientHandle))))
+            if (obj != null && obj.GetType() == typeof(SyslogRelayClientHandle))
             {
                 return ((SyslogRelayClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/WebInspector/WebInspectorClientHandle.cs
+++ b/iMobileDevice-net/WebInspector/WebInspectorClientHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="WebInspectorClientHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.WebInspector
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class WebInspectorClientHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for WebInspector handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class WebInspectorClientHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="WebInspectorClientHandle"/> class.
         /// </summary>
-        protected WebInspectorClientHandle() : 
+        protected WebInspectorClientHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="WebInspectorClientHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected WebInspectorClientHandle(bool ownsHandle) : 
+        protected WebInspectorClientHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.WebInspector
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.WebInspector
                 return WebInspectorClientHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.WebInspector.webinspector_client_free(this.handle) == WebInspectorError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.WebInspector
         /// </returns>
         public static WebInspectorClientHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            WebInspectorClientHandle safeHandle;
-            safeHandle = new WebInspectorClientHandle(ownsHandle);
+            WebInspectorClientHandle safeHandle = new WebInspectorClientHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.WebInspector
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(WebInspectorClientHandle))))
+            if (obj != null && obj.GetType() == typeof(WebInspectorClientHandle))
             {
                 return ((WebInspectorClientHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/iDevice/iDeviceConnectionHandle.cs
+++ b/iMobileDevice-net/iDevice/iDeviceConnectionHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="iDeviceConnectionHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.iDevice
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class iDeviceConnectionHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for iDevice handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class iDeviceConnectionHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="iDeviceConnectionHandle"/> class.
         /// </summary>
-        protected iDeviceConnectionHandle() : 
+        protected iDeviceConnectionHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="iDeviceConnectionHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected iDeviceConnectionHandle(bool ownsHandle) : 
+        protected iDeviceConnectionHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.iDevice
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.iDevice
                 return iDeviceConnectionHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.iDevice.idevice_disconnect(this.handle) == iDeviceError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.iDevice
         /// </returns>
         public static iDeviceConnectionHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            iDeviceConnectionHandle safeHandle;
-            safeHandle = new iDeviceConnectionHandle(ownsHandle);
+            iDeviceConnectionHandle safeHandle = new iDeviceConnectionHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.iDevice
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(iDeviceConnectionHandle))))
+            if (obj != null && obj.GetType() == typeof(iDeviceConnectionHandle))
             {
                 return ((iDeviceConnectionHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/iDevice/iDeviceHandle.cs
+++ b/iMobileDevice-net/iDevice/iDeviceHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="iDeviceHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.iDevice
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class iDeviceHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for iDevice handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class iDeviceHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="iDeviceHandle"/> class.
         /// </summary>
-        protected iDeviceHandle() : 
+        protected iDeviceHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="iDeviceHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected iDeviceHandle(bool ownsHandle) : 
+        protected iDeviceHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.iDevice
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.iDevice
                 return iDeviceHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             return (this.Api.iDevice.idevice_free(this.handle) == iDeviceError.Success);
         }
         
@@ -107,8 +100,7 @@ namespace iMobileDevice.iDevice
         /// </returns>
         public static iDeviceHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            iDeviceHandle safeHandle;
-            safeHandle = new iDeviceHandle(ownsHandle);
+            iDeviceHandle safeHandle = new iDeviceHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -135,7 +127,7 @@ namespace iMobileDevice.iDevice
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(iDeviceHandle))))
+            if (obj != null && obj.GetType() == typeof(iDeviceHandle))
             {
                 return ((iDeviceHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationApi.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationApi.cs
@@ -89,6 +89,7 @@ namespace iMobileDevice.iDeviceActivation
         public virtual void idevice_activation_request_get_fields(iDeviceActivationRequestHandle request, out PlistHandle fields)
         {
             iDeviceActivationNativeMethods.idevice_activation_request_get_fields(request, out fields);
+            fields.Api = this.Parent;
         }
         
         public virtual void idevice_activation_request_set_fields(iDeviceActivationRequestHandle request, PlistHandle fields)
@@ -155,6 +156,7 @@ namespace iMobileDevice.iDeviceActivation
         public virtual void idevice_activation_response_get_fields(iDeviceActivationResponseHandle response, out PlistHandle fields)
         {
             iDeviceActivationNativeMethods.idevice_activation_response_get_fields(response, out fields);
+            fields.Api = this.Parent;
         }
         
         public virtual void idevice_activation_response_get_label(iDeviceActivationResponseHandle response, string key, out string value)
@@ -175,11 +177,13 @@ namespace iMobileDevice.iDeviceActivation
         public virtual void idevice_activation_response_get_activation_record(iDeviceActivationResponseHandle response, out PlistHandle activationRecord)
         {
             iDeviceActivationNativeMethods.idevice_activation_response_get_activation_record(response, out activationRecord);
+            activationRecord.Api = this.Parent;
         }
         
         public virtual void idevice_activation_response_get_headers(iDeviceActivationResponseHandle response, out PlistHandle headers)
         {
             iDeviceActivationNativeMethods.idevice_activation_response_get_headers(response, out headers);
+            headers.Api = this.Parent;
         }
         
         public virtual int idevice_activation_response_is_activation_acknowledged(iDeviceActivationResponseHandle response)

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationRequestHandle.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationRequestHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="iDeviceActivationRequestHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.iDeviceActivation
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class iDeviceActivationRequestHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for iDeviceActivation handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class iDeviceActivationRequestHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="iDeviceActivationRequestHandle"/> class.
         /// </summary>
-        protected iDeviceActivationRequestHandle() : 
+        protected iDeviceActivationRequestHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="iDeviceActivationRequestHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected iDeviceActivationRequestHandle(bool ownsHandle) : 
+        protected iDeviceActivationRequestHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.iDeviceActivation
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.iDeviceActivation
                 return iDeviceActivationRequestHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             this.Api.iDeviceActivation.idevice_activation_request_free(this.handle);
             return true;
         }
@@ -108,8 +101,7 @@ namespace iMobileDevice.iDeviceActivation
         /// </returns>
         public static iDeviceActivationRequestHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            iDeviceActivationRequestHandle safeHandle;
-            safeHandle = new iDeviceActivationRequestHandle(ownsHandle);
+            iDeviceActivationRequestHandle safeHandle = new iDeviceActivationRequestHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -136,7 +128,7 @@ namespace iMobileDevice.iDeviceActivation
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(iDeviceActivationRequestHandle))))
+            if (obj != null && obj.GetType() == typeof(iDeviceActivationRequestHandle))
             {
                 return ((iDeviceActivationRequestHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice-net/iDeviceactivation/iDeviceActivationResponseHandle.cs
+++ b/iMobileDevice-net/iDeviceactivation/iDeviceActivationResponseHandle.cs
@@ -10,54 +10,48 @@
 // <copyright file="iDeviceActivationResponseHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.iDeviceActivation
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class iDeviceActivationResponseHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for iDeviceActivation handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class iDeviceActivationResponseHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="iDeviceActivationResponseHandle"/> class.
         /// </summary>
-        protected iDeviceActivationResponseHandle() : 
+        protected iDeviceActivationResponseHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="iDeviceActivationResponseHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected iDeviceActivationResponseHandle(bool ownsHandle) : 
+        protected iDeviceActivationResponseHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.iDeviceActivation
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,14 +77,13 @@ namespace iMobileDevice.iDeviceActivation
                 return iDeviceActivationResponseHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
             this.Api.iDeviceActivation.idevice_activation_response_free(this.handle);
             return true;
         }
@@ -108,8 +101,7 @@ namespace iMobileDevice.iDeviceActivation
         /// </returns>
         public static iDeviceActivationResponseHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            iDeviceActivationResponseHandle safeHandle;
-            safeHandle = new iDeviceActivationResponseHandle(ownsHandle);
+            iDeviceActivationResponseHandle safeHandle = new iDeviceActivationResponseHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -136,7 +128,7 @@ namespace iMobileDevice.iDeviceActivation
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(iDeviceActivationResponseHandle))))
+            if (obj != null && obj.GetType() == typeof(iDeviceActivationResponseHandle))
             {
                 return ((iDeviceActivationResponseHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice.Generator.Tests/TestHandle.cs.txt
+++ b/iMobileDevice.Generator.Tests/TestHandle.cs.txt
@@ -10,54 +10,48 @@
 // <copyright file="TestHandleHandle.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.Test
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class TestHandleHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for Test handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class TestHandleHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TestHandleHandle"/> class.
         /// </summary>
-        protected TestHandleHandle() : 
+        protected TestHandleHandle() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TestHandleHandle"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected TestHandleHandle(bool ownsHandle) : 
+        protected TestHandleHandle(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.Test
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,11 +77,9 @@ namespace iMobileDevice.Test
                 return TestHandleHandle.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             return true;
@@ -106,8 +98,7 @@ namespace iMobileDevice.Test
         /// </returns>
         public static TestHandleHandle DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            TestHandleHandle safeHandle;
-            safeHandle = new TestHandleHandle(ownsHandle);
+            TestHandleHandle safeHandle = new TestHandleHandle(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -134,7 +125,7 @@ namespace iMobileDevice.Test
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof(TestHandleHandle))))
+            if (obj != null && obj.GetType() == typeof(TestHandleHandle))
             {
                 return ((TestHandleHandle)obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice.Generator/Handle.cs.template
+++ b/iMobileDevice.Generator/Handle.cs.template
@@ -10,54 +10,48 @@
 // <copyright file="{{Name}}.cs" company="Quamotion">
 // Copyright (c) 2016-2018 Quamotion. All rights reserved.
 // </copyright>
-#pragma warning disable 1591
-#pragma warning disable 1572
-#pragma warning disable 1573
+
+using System;
+using System.Diagnostics;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
 
 namespace iMobileDevice.{{Namespace}}
 {
-    using System.Runtime.InteropServices;
-    using System.Diagnostics;
-    using iMobileDevice.iDevice;
-    using iMobileDevice.Lockdown;
-    using iMobileDevice.Afc;
-    using iMobileDevice.Plist;
-    
-    
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, UnmanagedCode=true)]
-#endif
-#if !NETSTANDARD1_5
-    [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, UnmanagedCode=true)]
-#endif
-    public partial class {{Name}} : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// Represents a wrapper class for {{Namespace}} handles.
+    /// </summary>
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode=true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode=true)]
+    public partial class {{Name}} : SafeHandleZeroOrMinusOneIsInvalid
     {
-        
         private string creationStackTrace;
-        
+
         private ILibiMobileDevice api;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="{{Name}}"/> class.
         /// </summary>
-        protected {{Name}}() : 
+        protected {{Name}}() :
                 base(true)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="{{Name}}"/> class, specifying whether the handle is to be reliably released.
         /// </summary>
         /// <param name="ownsHandle">
         /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent reliable release (not recommended).
         /// </param>
-        protected {{Name}}(bool ownsHandle) : 
+        protected {{Name}}(bool ownsHandle) :
                 base(ownsHandle)
         {
-            this.creationStackTrace = System.Environment.StackTrace;
+            this.creationStackTrace = Environment.StackTrace;
         }
-        
+
         /// <summary>
         /// Gets or sets the API to use
         /// </summary>
@@ -72,7 +66,7 @@ namespace iMobileDevice.{{Namespace}}
                 this.api = value;
             }
         }
-        
+
         /// <summary>
         /// Gets a value which represents a pointer or handle that has been initialized to zero.
         /// </summary>
@@ -83,18 +77,17 @@ namespace iMobileDevice.{{Namespace}}
                 return {{Name}}.DangerousCreate(System.IntPtr.Zero);
             }
         }
-        
+
         /// <inheritdoc/>
-#if !NETSTANDARD1_5
-        [System.Runtime.ConstrainedExecution.ReliabilityContractAttribute(System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState, System.Runtime.ConstrainedExecution.Cer.MayFail)]
-#endif
+        [ReliabilityContractAttribute(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
 {{^ReleaseMethodName}}
             return true;
 {{/ReleaseMethodName}}
 {{#ReleaseMethodName}}
-            System.Diagnostics.Debug.WriteLine("Releasing {0} {1} using {2}. This object was created at {3}", this.GetType().Name, this.handle, this.Api, this.creationStackTrace);
+            Debug.WriteLine($"Releasing {this.GetType().Name} {this.handle} using {this.Api}. This object was created at {this.creationStackTrace}");
+            Debug.Assert(this.Api != null, $"An instance of {this.GetType().Name} is being released but is not tied to an instance of the API.");
 {{#ReleaseMethodReturnsValue}}
             return (this.Api.{{Namespace}}.{{ReleaseMethodName}}(this.handle) == {{Namespace}}Error.Success);
 {{/ReleaseMethodReturnsValue}}
@@ -118,8 +111,7 @@ namespace iMobileDevice.{{Namespace}}
         /// </returns>
         public static {{Name}} DangerousCreate(System.IntPtr unsafeHandle, bool ownsHandle)
         {
-            {{Name}} safeHandle;
-            safeHandle = new {{Name}}(ownsHandle);
+            {{Name}} safeHandle = new {{Name}}(ownsHandle);
             safeHandle.SetHandle(unsafeHandle);
             return safeHandle;
         }
@@ -146,7 +138,7 @@ namespace iMobileDevice.{{Namespace}}
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (((obj != null) & (obj.GetType() == typeof({{Name}}))))
+            if (obj != null && obj.GetType() == typeof({{Name}}))
             {
                 return (({{Name}})obj).handle.Equals(this.handle);
             }

--- a/iMobileDevice.Generator/Program.cs
+++ b/iMobileDevice.Generator/Program.cs
@@ -31,12 +31,18 @@ namespace iMobileDevice.Generator
 
             RestoreClang();
 
-            var packagesDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
             targetDirectory = Path.GetFullPath(targetDirectory);
-            
+
             Console.WriteLine($"Writing the C# files to: {targetDirectory}");
 
             var vcpkgPath = Environment.GetEnvironmentVariable("VCPKG_ROOT");
+
+            if (vcpkgPath == null)
+            {
+                Console.Error.WriteLine("Please set the VCPKG_ROOT environment variable to the folder where you've installed VCPKG.");
+                return;
+            }
+
             vcpkgPath = Path.Combine(vcpkgPath, "installed", "x86-windows", "include");
             Console.WriteLine($"Reading include files from {vcpkgPath}");
 
@@ -50,10 +56,9 @@ namespace iMobileDevice.Generator
             Collection<string> names = new Collection<string>();
 
             var files = new List<string>();
-            files.Add(Path.Combine(packagesDirectory, Path.Combine(vcpkgPath, "usbmuxd.h")));
-            files.Add(Path.Combine(packagesDirectory, Path.Combine(vcpkgPath, "plist/plist.h")));
-            files.Add(Path.Combine(packagesDirectory, Path.Combine(vcpkgPath, "libideviceactivation.h")));
-
+            files.Add(Path.Combine(vcpkgPath, "usbmuxd.h"));
+            files.Add(Path.Combine(vcpkgPath, "plist/plist.h"));
+            files.Add(Path.Combine(vcpkgPath, "libideviceactivation.h"));
             var iMobileDeviceDirectory = Path.Combine(vcpkgPath, "libimobiledevice");
             files.Add(Path.Combine(iMobileDeviceDirectory, "libimobiledevice.h"));
             files.Add(Path.Combine(iMobileDeviceDirectory, "lockdown.h"));

--- a/iMobileDevice.Tests/AfcApiTests.cs
+++ b/iMobileDevice.Tests/AfcApiTests.cs
@@ -1,0 +1,166 @@
+﻿using iMobileDevice.Afc;
+using iMobileDevice.iDevice;
+using iMobileDevice.Lockdown;
+using System;
+using System.Collections.ObjectModel;
+using Xunit;
+
+namespace iMobileDevice.Tests
+{
+    /// <summary>
+    /// Tests the methods of the <see cref="AfcApi"/> class which can be invoked without connecting to a device, or partial error handling
+    /// of methods which should connect to a device. This is a first test to make sure the P/Invoke declarations are correct.
+    /// </summary>
+    public class AfcApiTests
+    {
+        private readonly LibiMobileDevice api = new LibiMobileDevice();
+
+        [Fact]
+        public void AfcClientFreeZero()
+        {
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_client_free(IntPtr.Zero));
+        }
+
+        [Fact]
+        public void AfcClientNewZero()
+        {
+            AfcClientHandle afc;
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_client_new(iDeviceHandle.Zero, LockdownServiceDescriptorHandle.Zero, out afc));
+        }
+
+        [Fact]
+        public void AfcClientStartServiceZero()
+        {
+            AfcClientHandle afc;
+            Assert.Equal(AfcError.UnknownError, this.api.Afc.afc_client_start_service(iDeviceHandle.Zero, out afc, "test"));
+        }
+
+        [Fact]
+        public void AfcDictionaryFreeZero()
+        {
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_dictionary_free(IntPtr.Zero));
+        }
+
+        [Fact]
+        public void AfcFileCloseZero()
+        {
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_file_close(AfcClientHandle.Zero, 0));
+        }
+
+        [Fact]
+        public void AfcFileLockZero()
+        {
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_file_lock(AfcClientHandle.Zero, 0, AfcLockOp.LockEx));
+        }
+
+        [Fact]
+        public void AfcFileOpenZero()
+        {
+            ulong file = 0;
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_file_open(AfcClientHandle.Zero, "test", AfcFileMode.FopenRdonly, ref file));
+        }
+
+        [Fact]
+        public void AfcFileReadZero()
+        {
+            uint bytesRead = 0;
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_file_read(AfcClientHandle.Zero, 0, Array.Empty<byte>(), 0, ref bytesRead));
+        }
+
+        [Fact]
+        public void AfcFileSeekZero()
+        {
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_file_seek(AfcClientHandle.Zero, 0, 0, 0));
+        }
+
+        [Fact]
+        public void AfcFileTellZero()
+        {
+            ulong position = 0;
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_file_tell(AfcClientHandle.Zero, 0, ref position));
+        }
+
+        [Fact]
+        public void AfcFileTruncateZero()
+        {
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_file_truncate(AfcClientHandle.Zero, 0, 0));
+        }
+
+        [Fact]
+        public void AfcFileWriteZero()
+        {
+            uint bytesWritten = 0;
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_file_write(AfcClientHandle.Zero, 0, Array.Empty<byte>(), 0, ref bytesWritten));
+        }
+
+        [Fact]
+        public void AfcGetDeviceInfoZero()
+        {
+            ReadOnlyCollection<string> deviceInformation;
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_get_device_info(AfcClientHandle.Zero, out deviceInformation));
+        }
+
+        [Fact]
+        public void AfcGetDeviceInfoKeyZero()
+        {
+            string value;
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_get_device_info_key(AfcClientHandle.Zero, "test", out value));
+        }
+
+        [Fact]
+        public void AfcGetFileInfoZer()
+        {
+            ReadOnlyCollection<string> fileInformation;
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_get_file_info(AfcClientHandle.Zero, "test", out fileInformation));
+        }
+
+        [Fact]
+        public void AfcMakeDirectoryZero()
+        {
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_make_directory(AfcClientHandle.Zero, "test"));
+        }
+
+        [Fact]
+        public void AfcMakeLinkZero()
+        {
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_make_link(AfcClientHandle.Zero, AfcLinkType.Hardlink, "/foo", "/bar"));
+        }
+
+        [Fact]
+        public void AfcReadDirectoryZer()
+        {
+            ReadOnlyCollection<string> directoryInformation;
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_read_directory(AfcClientHandle.Zero, "/test/", out directoryInformation));
+        }
+
+        [Fact]
+        public void AfcRemovePathZero()
+        {
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_remove_path(AfcClientHandle.Zero, "/test"));
+        }
+
+        [Fact]
+        public void AfcRemovePathAndContentsZero()
+        {
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_remove_path_and_contents(AfcClientHandle.Zero, "/test"));
+        }
+
+        [Fact]
+        public void AfcRenamePathZero()
+        {
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_rename_path(AfcClientHandle.Zero, "/foo", "/bar"));
+        }
+
+        [Fact]
+        public void AfcSetFileTimeZero()
+        {
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_set_file_time(AfcClientHandle.Zero, "/foo", 0));
+        }
+
+        [Fact]
+        public void AfcTruncateZero()
+        {
+            Assert.Equal(AfcError.InvalidArg, this.api.Afc.afc_truncate(AfcClientHandle.Zero, "/foo", 0));
+        }
+    }
+}

--- a/iMobileDevice.Tests/DebugServerApiTests.cs
+++ b/iMobileDevice.Tests/DebugServerApiTests.cs
@@ -1,0 +1,125 @@
+﻿using iMobileDevice.DebugServer;
+using iMobileDevice.iDevice;
+using iMobileDevice.Lockdown;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Xunit;
+
+namespace iMobileDevice.Tests
+{
+    /// <summary>
+    /// Tests the methods of the <see cref="AfcApi"/> class which can be invoked without connecting to a device, or partial error handling
+    /// of methods which should connect to a device. This is a first test to make sure the P/Invoke declarations are correct.
+    /// </summary>
+    public class DebugServerApiTests
+    {
+        private readonly LibiMobileDevice api = new LibiMobileDevice();
+
+        [Fact]
+        public void DebugServerClientFreeZero()
+        {
+            Assert.Equal(DebugServerError.InvalidArg, this.api.DebugServer.debugserver_client_free(IntPtr.Zero));
+        }
+
+        [Fact]
+        public void DebugServerClientNewZero()
+        {
+            Assert.Equal(DebugServerError.InvalidArg, this.api.DebugServer.debugserver_client_new(iDeviceHandle.Zero, LockdownServiceDescriptorHandle.Zero, out DebugServerClientHandle client));
+        }
+
+        [Fact]
+        public void DebugServerClientReceiveZero()
+        {
+            uint received = 0;
+            Assert.Equal(DebugServerError.InvalidArg, this.api.DebugServer.debugserver_client_receive(DebugServerClientHandle.Zero, Array.Empty<byte>(), 0, ref received));
+        }
+
+        [Fact (Skip = "debugserver_client_receive_response does not check for null values")]
+        public void DebugServerClientReceiveResponseZero()
+        {
+            string response;
+            Assert.Equal(DebugServerError.InvalidArg, this.api.DebugServer.debugserver_client_receive_response(DebugServerClientHandle.Zero, out response));
+        }
+
+        [Fact]
+        public void DebugServerClientReceiveWithTimeoutZero()
+        {
+            uint received = 0;
+            Assert.Equal(DebugServerError.InvalidArg, this.api.DebugServer.debugserver_client_receive_with_timeout(DebugServerClientHandle.Zero, Array.Empty<byte>(), 0, ref received, 0));
+        }
+
+        [Fact]
+        public void DebugServerClientSendZero()
+        {
+            uint sent = 0;
+            Assert.Equal(DebugServerError.InvalidArg, this.api.DebugServer.debugserver_client_send(DebugServerClientHandle.Zero, Array.Empty<byte>(), 0, ref sent));
+        }
+
+        [Fact(Skip = "debugserver_client_send_command does not check for null values")]
+        public void DebugServerClientSendCommandZero()
+        {
+            Assert.Equal(DebugServerError.InvalidArg, this.api.DebugServer.debugserver_client_send_command(DebugServerClientHandle.Zero, DebugServerCommandHandle.Zero, out string response));
+        }
+
+        [Fact]
+        public void DebugServerClientSetAckModeZero()
+        {
+            Assert.Equal(DebugServerError.InvalidArg, this.api.DebugServer.debugserver_client_set_ack_mode(DebugServerClientHandle.Zero, 0));
+        }
+
+        [Fact]
+        public void DebugServerClientSetArgVZero()
+        {
+            Assert.Equal(DebugServerError.InvalidArg, this.api.DebugServer.debugserver_client_set_argv(DebugServerClientHandle.Zero, 0, new ReadOnlyCollection<string>(new List<string>()), out string response));
+        }
+
+        [Fact]
+        public void DebugServerClientSetEnvironmentHexEncodedZero()
+        {
+            Assert.Equal(DebugServerError.InvalidArg, this.api.DebugServer.debugserver_client_set_environment_hex_encoded(DebugServerClientHandle.Zero, "abc", out string response));
+        }
+
+        [Fact]
+        public void DebugServerClientStartServiceZero()
+        {
+            Assert.Equal(DebugServerError.UnknownError, this.api.DebugServer.debugserver_client_start_service(iDeviceHandle.Zero, out DebugServerClientHandle client, "test"));
+        }
+
+        [Fact]
+        public void DebugServerCommandFreeZero()
+        {
+            Assert.Equal(DebugServerError.InvalidArg, this.api.DebugServer.debugserver_command_free(IntPtr.Zero));
+        }
+
+        [Fact]
+        public void DebugServerCommandNew()
+        {
+            DebugServerCommandHandle command;
+            Assert.Equal(DebugServerError.Success, this.api.DebugServer.debugserver_command_new("test", 0, new ReadOnlyCollection<string>(new List<string>()), out command));
+            Assert.NotEqual(IntPtr.Zero, command.DangerousGetHandle());
+            Assert.Equal(this.api, command.Api);
+            command.Dispose();
+        }
+
+        [Fact]
+        public void DebugServerDecodeString()
+        {
+            var encodedString = "7175616D6F74696F6E";
+            this.api.DebugServer.debugserver_decode_string(encodedString, (uint)encodedString.Length, out string buffer);
+            Assert.Equal("quamotion", buffer);
+        }
+
+        [Fact]
+        public void DebugServerEncodeString()
+        {
+            var stringToEncode = "quamotion";
+            uint encodedLength = 0;
+            this.api.DebugServer.debugserver_encode_string(stringToEncode, out string encodedBuffer, ref encodedLength);
+            Assert.Equal("7175616D6F74696F6E", encodedBuffer);
+
+            // *encoded_length = (2 * length) + DEBUGSERVER_CHECKSUM_HASH_LENGTH + 1;
+            Assert.Equal(22u, encodedLength);
+        }
+    }
+}

--- a/iMobileDevice.Tests/DiagnosticsRelayApiTests.cs
+++ b/iMobileDevice.Tests/DiagnosticsRelayApiTests.cs
@@ -1,0 +1,84 @@
+﻿using iMobileDevice.DiagnosticsRelay;
+using iMobileDevice.iDevice;
+using iMobileDevice.Lockdown;
+using iMobileDevice.Plist;
+using System;
+using Xunit;
+
+namespace iMobileDevice.Tests
+{
+    /// <summary>
+    /// Tests the methods of the <see cref="DiagnosticsRelayApi"/> class which can be invoked without connecting to a device, or partial error handling
+    /// of methods which should connect to a device. This is a first test to make sure the P/Invoke declarations are correct.
+    /// </summary>
+    public class DiagnosticsRelayApiTests
+    {
+        private readonly LibiMobileDevice api = new LibiMobileDevice();
+
+        [Fact]
+        public void DiagnosticsRelayClientFreeZero()
+        {
+            Assert.Equal(DiagnosticsRelayError.InvalidArg, this.api.DiagnosticsRelay.diagnostics_relay_client_free(IntPtr.Zero));
+        }
+
+        [Fact]
+        public void DiagnosticsRelayClientNewZero()
+        {
+            Assert.Equal(DiagnosticsRelayError.InvalidArg, this.api.DiagnosticsRelay.diagnostics_relay_client_new(iDeviceHandle.Zero, LockdownServiceDescriptorHandle.Zero, out DiagnosticsRelayClientHandle client));
+        }
+
+        [Fact]
+        public void DiagnosticsRelayClientStartServiceZero()
+        {
+            Assert.Equal(DiagnosticsRelayError.UnknownError, this.api.DiagnosticsRelay.diagnostics_relay_client_start_service(iDeviceHandle.Zero, out DiagnosticsRelayClientHandle client, "test"));
+        }
+
+        [Fact]
+        public void DiagnosticsRelayGoodbyeZero()
+        {
+            Assert.Equal(DiagnosticsRelayError.InvalidArg, this.api.DiagnosticsRelay.diagnostics_relay_goodbye(DiagnosticsRelayClientHandle.Zero));
+        }
+
+        [Fact]
+        public void DiagnosticsRelayQueryIORegistryEntryZero()
+        {
+            Assert.Equal(DiagnosticsRelayError.InvalidArg, this.api.DiagnosticsRelay.diagnostics_relay_query_ioregistry_entry(DiagnosticsRelayClientHandle.Zero, "test", "abc", out PlistHandle result));
+        }
+
+        [Fact]
+        public void DiagnosticsRelayQueryIORegistryPlaneZero()
+        {
+            Assert.Equal(DiagnosticsRelayError.InvalidArg, this.api.DiagnosticsRelay.diagnostics_relay_query_ioregistry_plane(DiagnosticsRelayClientHandle.Zero, "test", out PlistHandle result));
+        }
+
+        [Fact]
+        public void DiagnosticsRelayQueryMobileGestaltZero()
+        {
+            Assert.Equal(DiagnosticsRelayError.InvalidArg, this.api.DiagnosticsRelay.diagnostics_relay_query_mobilegestalt(DiagnosticsRelayClientHandle.Zero, PlistHandle.Zero, out PlistHandle result));
+        }
+
+        [Fact]
+        public void DiagnosticsRelayRequestDiagnosticsZero()
+        {
+            Assert.Equal(DiagnosticsRelayError.InvalidArg, this.api.DiagnosticsRelay.diagnostics_relay_request_diagnostics(DiagnosticsRelayClientHandle.Zero, "type", out PlistHandle diagnostics));
+        }
+
+        [Fact]
+        public void DiagnosticRelayRestartZero()
+        {
+            Assert.Equal(DiagnosticsRelayError.InvalidArg, this.api.DiagnosticsRelay.diagnostics_relay_restart(DiagnosticsRelayClientHandle.Zero, DiagnosticsRelayAction.ActionFlagDisplayFail));
+        }
+
+        [Fact]
+        public void DiagnosticsRelayShutdownZero()
+        {
+            Assert.Equal(DiagnosticsRelayError.InvalidArg, this.api.DiagnosticsRelay.diagnostics_relay_shutdown(DiagnosticsRelayClientHandle.Zero, DiagnosticsRelayAction.ActionFlagDisplayFail));
+        }
+
+        [Fact]
+        public void DiagnosticRelaySleepZero()
+        { 
+            Assert.Equal(DiagnosticsRelayError.InvalidArg, this.api.DiagnosticsRelay.diagnostics_relay_sleep(DiagnosticsRelayClientHandle.Zero));
+        }
+    }
+}

--- a/iMobileDevice.Tests/FileRelayApiTests.cs
+++ b/iMobileDevice.Tests/FileRelayApiTests.cs
@@ -1,0 +1,47 @@
+﻿using iMobileDevice.FileRelay;
+using iMobileDevice.iDevice;
+using iMobileDevice.Lockdown;
+using System;
+using Xunit;
+
+namespace iMobileDevice.Tests
+{
+    /// <summary>
+    /// Tests the methods of the <see cref="FileRelayApi"/> class which can be invoked without connecting to a device, or partial error handling
+    /// of methods which should connect to a device. This is a first test to make sure the P/Invoke declarations are correct.
+    /// </summary>
+    public class FileRelayApiTests
+    {
+        private readonly LibiMobileDevice api = new LibiMobileDevice();
+
+        [Fact]
+        public void FileRelayClientFreeZero()
+        {
+            Assert.Equal(FileRelayError.InvalidArg, this.api.FileRelay.file_relay_client_free(IntPtr.Zero));
+        }
+
+        [Fact]
+        public void FileRelayClientNewZero()
+        {
+            Assert.Equal(FileRelayError.InvalidArg, this.api.FileRelay.file_relay_client_new(iDeviceHandle.Zero, LockdownServiceDescriptorHandle.Zero, out FileRelayClientHandle client));
+        }
+
+        [Fact]
+        public void FileRelayClientStartServiceZero()
+        {
+            Assert.Equal(FileRelayError.UnknownError, this.api.FileRelay.file_relay_client_start_service(iDeviceHandle.Zero, out FileRelayClientHandle client, "test"));
+        }
+
+        [Fact]
+        public void FileRelayRequestSourcesZero()
+        {
+            Assert.Equal(FileRelayError.InvalidArg, this.api.FileRelay.file_relay_request_sources(FileRelayClientHandle.Zero, out string sources, out iDeviceConnectionHandle connection));
+        }
+
+        [Fact]
+        public void FileRelayRequestSourcesTimeoutZero()
+        {
+            Assert.Equal(FileRelayError.InvalidArg, this.api.FileRelay.file_relay_request_sources_timeout(FileRelayClientHandle.Zero, out string sources, out iDeviceConnectionHandle connection, 0));
+        }
+    }
+}

--- a/iMobileDevice.Tests/HandleTests.cs
+++ b/iMobileDevice.Tests/HandleTests.cs
@@ -19,8 +19,8 @@
         [Fact]
         public void EqualsTest()
         {
-            AfcClientHandle handle = AfcClientHandle.DangerousCreate(new IntPtr(42));
-            AfcClientHandle handle2 = AfcClientHandle.DangerousCreate(new IntPtr(42));
+            AfcClientHandle handle = AfcClientHandle.DangerousCreate(new IntPtr(42), ownsHandle: false);
+            AfcClientHandle handle2 = AfcClientHandle.DangerousCreate(new IntPtr(42), ownsHandle: false);
             AfcClientHandle zero = AfcClientHandle.Zero;
 
             Assert.True(handle.Equals(handle));

--- a/iMobileDevice.Tests/HeartBeatApiTests.cs
+++ b/iMobileDevice.Tests/HeartBeatApiTests.cs
@@ -1,0 +1,54 @@
+﻿using iMobileDevice.HeartBeat;
+using iMobileDevice.iDevice;
+using iMobileDevice.Lockdown;
+using iMobileDevice.Plist;
+using System;
+using Xunit;
+
+namespace iMobileDevice.Tests
+{
+    /// <summary>
+    /// Tests the methods of the <see cref="HeartBeatApi"/> class which can be invoked without connecting to a device, or partial error handling
+    /// of methods which should connect to a device. This is a first test to make sure the P/Invoke declarations are correct.
+    /// </summary>
+    public class HeartBeatApiTests
+    {
+        private readonly LibiMobileDevice api = new LibiMobileDevice();
+
+        [Fact]
+        public void HeartBeatClientFreeZero()
+        {
+            Assert.Equal(HeartBeatError.InvalidArg, api.HeartBeat.heartbeat_client_free(IntPtr.Zero));
+        }
+
+        [Fact]
+        public void HeartBeatClientNewZero()
+        {
+            Assert.Equal(HeartBeatError.InvalidArg, api.HeartBeat.heartbeat_client_new(iDeviceHandle.Zero, LockdownServiceDescriptorHandle.Zero, out HeartBeatClientHandle client));
+        }
+
+        [Fact]
+        public void HeartBeatClientStartServiceZero()
+        {
+            Assert.Equal(HeartBeatError.UnknownError, api.HeartBeat.heartbeat_client_start_service(iDeviceHandle.Zero, out HeartBeatClientHandle client, "test"));
+        }
+
+        [Fact(Skip = "heartbeat_receive does not check for null values")]
+        public void HeartBeatReceiveZero()
+        {
+            Assert.Equal(HeartBeatError.InvalidArg, api.HeartBeat.heartbeat_receive(HeartBeatClientHandle.Zero, out PlistHandle plist));
+        }
+
+        [Fact(Skip = "heartbeat_receive_with_timeout does not check for null values")]
+        public void HeartBeatReceiveWithTimeoutZero()
+        {
+            Assert.Equal(HeartBeatError.InvalidArg, api.HeartBeat.heartbeat_receive_with_timeout(HeartBeatClientHandle.Zero, out PlistHandle plist, 0));
+        }
+
+        [Fact(Skip = "heartbeat_send does not check for null values")]
+        public void HeartBeatSendZero()
+        {
+            Assert.Equal(HeartBeatError.InvalidArg, api.HeartBeat.heartbeat_send(HeartBeatClientHandle.Zero, PlistHandle.Zero));
+        }
+    }
+}

--- a/iMobileDevice.Tests/HouseArrestApiTests.cs
+++ b/iMobileDevice.Tests/HouseArrestApiTests.cs
@@ -1,0 +1,61 @@
+﻿using iMobileDevice.Afc;
+using iMobileDevice.HouseArrest;
+using iMobileDevice.iDevice;
+using iMobileDevice.Lockdown;
+using iMobileDevice.Plist;
+using System;
+using Xunit;
+
+namespace iMobileDevice.Tests
+{
+    /// <summary>
+    /// Tests the methods of the <see cref="HouseArrestApi"/> class which can be invoked without connecting to a device, or partial error handling
+    /// of methods which should connect to a device. This is a first test to make sure the P/Invoke declarations are correct.
+    /// </summary>
+    public class HouseArrestApiTests
+    {
+        private readonly LibiMobileDevice api = new LibiMobileDevice();
+
+        [Fact]
+        public void AfcClientNewFromHouseArrestClientZero()
+        {
+            Assert.Equal(AfcError.InvalidArg, this.api.HouseArrest.afc_client_new_from_house_arrest_client(HouseArrestClientHandle.Zero, out AfcClientHandle afcClient));
+        }
+
+        [Fact]
+        public void HouseArrestClientFreeZero()
+        {
+            Assert.Equal(HouseArrestError.InvalidArg, this.api.HouseArrest.house_arrest_client_free(IntPtr.Zero));
+        }
+
+        [Fact]
+        public void HouseArrestClientNewZero()
+        {
+            Assert.Equal(HouseArrestError.InvalidArg, this.api.HouseArrest.house_arrest_client_new(iDeviceHandle.Zero, LockdownServiceDescriptorHandle.Zero, out HouseArrestClientHandle client));
+        }
+
+        [Fact]
+        public void HouseArrestClientStartServiceZero()
+        {
+            Assert.Equal(HouseArrestError.UnknownError, this.api.HouseArrest.house_arrest_client_start_service(iDeviceHandle.Zero, out HouseArrestClientHandle client, "test"));
+        }
+
+        [Fact]
+        public void HouseArrestGetResultZero()
+        {
+            Assert.Equal(HouseArrestError.InvalidArg, this.api.HouseArrest.house_arrest_get_result(HouseArrestClientHandle.Zero, out PlistHandle dict));
+        }
+
+        [Fact]
+        public void HouseArrestSendCommandZero()
+        {
+            Assert.Equal(HouseArrestError.InvalidArg, this.api.HouseArrest.house_arrest_send_command(HouseArrestClientHandle.Zero, "test", "appId"));
+        }
+
+        [Fact]
+        public void HouseArrestSendRequestZero()
+        {
+            Assert.Equal(HouseArrestError.InvalidArg, this.api.HouseArrest.house_arrest_send_request(HouseArrestClientHandle.Zero, PlistHandle.Zero));
+        }
+    }
+}

--- a/iMobileDevice.Tests/NativeStringArrayMarshalerTests.cs
+++ b/iMobileDevice.Tests/NativeStringArrayMarshalerTests.cs
@@ -8,7 +8,7 @@ namespace iMobileDevice.Tests
 {
     public class NativeStringArrayMarshalerTests
     {
-        [Fact]
+        [Fact (Skip = "This test should run in its own context")]
         public void TestRoundTrip()
         {
             NativeLibraries.Load();

--- a/iMobileDevice.Tests/NativeStringMarshalerTests.cs
+++ b/iMobileDevice.Tests/NativeStringMarshalerTests.cs
@@ -7,7 +7,7 @@ namespace iMobileDevice.Tests
 {
     public class NativeStringMarshalerTests
     {
-        [Fact]
+        [Fact(Skip = "This test should run in its own context")]
         public void NativeToManagedTest()
         {
             NativeLibraries.Load();

--- a/iMobileDevice.Tests/iDeviceApiTests.cs
+++ b/iMobileDevice.Tests/iDeviceApiTests.cs
@@ -1,0 +1,149 @@
+﻿using iMobileDevice.iDevice;
+using System;
+using System.Collections.ObjectModel;
+using Xunit;
+
+namespace iMobileDevice.Tests
+{
+    /// <summary>
+    /// Tests the methods of the <see cref="iDeviceApi"/> class which can be invoked without connecting to a device, or partial error handling
+    /// of methods which should connect to a device. This is a first test to make sure the P/Invoke declarations are correct.
+    /// </summary>
+    public class iDeviceApiTests
+    {
+        private readonly LibiMobileDevice api = new LibiMobileDevice();
+
+        [Fact]
+        public void iDeviceConnectZero()
+        {
+            Assert.Equal(iDeviceError.InvalidArg, this.api.iDevice.idevice_connect(iDeviceHandle.Zero, 0, out iDeviceConnectionHandle connection));
+        }
+
+        [Fact]
+        public void iDeviceConnectionDisableSslZero()
+        {
+            Assert.Equal(iDeviceError.InvalidArg, this.api.iDevice.idevice_connection_disable_ssl(iDeviceConnectionHandle.Zero));
+        }
+
+        [Fact]
+        public void iDeviceConnectionEnableSslZero()
+        {
+            Assert.Equal(iDeviceError.InvalidArg, this.api.iDevice.idevice_connection_enable_ssl(iDeviceConnectionHandle.Zero));
+        }
+
+        [Fact]
+        public void iDeviceConnectionGetFdZero()
+        {
+            int fd = 0;
+            Assert.Equal(iDeviceError.InvalidArg, this.api.iDevice.idevice_connection_get_fd(iDeviceConnectionHandle.Zero, ref fd));
+        }
+
+        [Fact]
+        public void iDeviceConnectionReceiveZero()
+        {
+            uint recvBytes = 0;
+            Assert.Equal(iDeviceError.InvalidArg, this.api.iDevice.idevice_connection_receive(iDeviceConnectionHandle.Zero, Array.Empty<byte>(), 0, ref recvBytes));
+        }
+
+        [Fact]
+        public void iDeviceConnectionReceiveTimeoutZero()
+        {
+            uint recvBytes = 0;
+            Assert.Equal(iDeviceError.InvalidArg, this.api.iDevice.idevice_connection_receive_timeout(iDeviceConnectionHandle.Zero, Array.Empty<byte>(), 0, ref recvBytes, 0));
+        }
+
+        [Fact]
+        public void iDeviceConnectionSendZero()
+        {
+            uint sentBytes = 0;
+            Assert.Equal(iDeviceError.InvalidArg, this.api.iDevice.idevice_connection_send(iDeviceConnectionHandle.Zero, Array.Empty<byte>(), 0, ref sentBytes));
+        }
+
+        [Fact]
+        public void iDeviceDeviceListFreeZero()
+        {
+            // Most _free methods return InvalidArg when passed a NULL value, idevice_device_list_free however returns SUCCESS
+            // (but does nothing)
+            Assert.Equal(iDeviceError.Success, this.api.iDevice.idevice_device_list_free(IntPtr.Zero));
+        }
+
+        [Fact]
+        public void iDeviceDisconnectZero()
+        {
+            Assert.Equal(iDeviceError.InvalidArg, this.api.iDevice.idevice_disconnect(IntPtr.Zero));
+        }
+
+        [Fact]
+        public void iDeviceEventSubscribeUnsubscribe()
+        {
+            iDeviceEventCallBack callback = null;
+            Assert.Equal(iDeviceError.Success, this.api.iDevice.idevice_event_subscribe(callback, IntPtr.Zero));
+            Assert.Equal(iDeviceError.Success, this.api.iDevice.idevice_event_unsubscribe());
+        }
+
+        [Fact]
+        public void iDeviceFreeZero()
+        {
+            Assert.Equal(iDeviceError.InvalidArg, this.api.iDevice.idevice_free(IntPtr.Zero));
+        }
+
+        [Fact (Skip = "Flaky, integration test")]
+        public void iDeviceGetDeviceListZero()
+        {
+            int count = 0;
+            Assert.Equal(iDeviceError.NoDevice, this.api.iDevice.idevice_get_device_list(out ReadOnlyCollection<string> devices, ref count));
+        }
+
+        [Fact]
+        public void iDeviceGetHandleZero()
+        {
+            uint handle = 0;
+            Assert.Equal(iDeviceError.InvalidArg, this.api.iDevice.idevice_get_handle(iDeviceHandle.Zero, ref handle));
+        }
+
+        [Fact]
+        public void iDeviceGetSetSocketType()
+        {
+            int socketType = 0;
+            Assert.Equal(iDeviceError.Success, this.api.iDevice.idevice_set_socket_type((int)iDeviceSocketType.SocketTypeTcp));
+            Assert.Equal(iDeviceError.Success, this.api.iDevice.idevice_get_socket_type(ref socketType));
+            Assert.Equal(iDeviceSocketType.SocketTypeTcp, (iDeviceSocketType)socketType);
+        }
+
+        [Fact]
+        public void iDeviceGetSetTcpEndpoint()
+        {
+            Assert.Equal(iDeviceError.Success, this.api.iDevice.idevice_set_tcp_endpoint("localhost", 9999));
+
+            ushort port = 0;
+            Assert.Equal(iDeviceError.Success, this.api.iDevice.idevice_get_tcp_endpoint(out string host, ref port));
+            Assert.Equal("localhost", host);
+            Assert.Equal(9999, port);
+        }
+
+        [Fact]
+        public void iDeviceGetUdidZero()
+        {
+            Assert.Equal(iDeviceError.InvalidArg, this.api.iDevice.idevice_get_udid(iDeviceHandle.Zero, out string udid));
+        }
+
+        [Fact]
+        public void iDeviceNewZero()
+        {
+            Assert.Equal(iDeviceError.NoDevice, this.api.iDevice.idevice_new(out iDeviceHandle handle, string.Empty));
+        }
+
+        [Fact(Skip = "No way to unregister callback")]
+        public void iDeviceSetDebugCallback()
+        {
+            iDeviceDebugCallBack debugCallback = null;
+            this.api.iDevice.idevice_set_debug_callback(debugCallback);
+        }
+
+        [Fact]
+        public void iDeviceSetDebugLevel()
+        {
+            this.api.iDevice.idevice_set_debug_level(1);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a first round of unit tests to the imobiledevice-net library itself. It tests the generated code and makes sure it can interact (in a very basic way) with the native libraries.

- The tests run on both AppVeyor and Travis (Linux). They use the native binaries built from vcpkg (Windows) and the Ubuntu PPAs (Linux).
- On Windows, the probing for native libraries has been simplified a bit, and we now use SetDllDirectory to set the directory in which Windows should look for the native libraries when loading them.
- Most of the native code tries to connect to an actual device, which is not available on the CI systems. Instead, try to invoke these methods with invalid arguments and make sure an error is returned. This makes sure that at least the basic interaction with the native node is working.
- A couple of issues have been found related to the Handles. Not all handles had their Api property set. The Handle code has been updated, and cleaned up at the same time.
- A couple of issues have been uncovered in the build process for the native libraries; they have been fixed separately.