### PR TITLE
Run .NET 4.5 integration tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,9 @@ image: Visual Studio 2017
 environment:
   VCPKG_ROOT: C:\tools\vcpkg-libimobiledevice
 
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
 before_build:
   - vcpkg version
   - git version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,6 +58,18 @@ build_script:
   - dotnet test iMobileDevice.Generator.Tests\iMobileDevice.Generator.Tests.csproj
   - dotnet test iMobileDevice.Tests\iMobileDevice.Tests.csproj
 
+  # Run integration tests
+  - mkdir packages
+  - nuget init iMobileDevice-net\bin\Release\ packages
+  - cd iMobileDevice.IntegrationTests.net45
+  - powershell -File PatchNuGet.ps1
+  - nuget restore
+  - msbuild.exe /p:Configuration=Release /p:Platform=x86
+  - msbuild.exe /p:Configuration=Release /p:Platform=x64
+  - bin\x86\Release\iMobileDevice.IntegrationTests.net45.exe
+  - bin\x64\Release\iMobileDevice.IntegrationTests.net45.exe
+  - cd ..
+
 artifacts:
   - path: imobiledevice-net\bin\Release\imobiledevice-net.*.nupkg
     name: imobiledevice-net

--- a/iMobileDevice.IntegrationTests.net45/App.config
+++ b/iMobileDevice.IntegrationTests.net45/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/iMobileDevice.IntegrationTests.net45/NuGet.config
+++ b/iMobileDevice.IntegrationTests.net45/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear /> <!-- ensure only the sources defined below are used -->
+        <add key="CI packages" value="..\packages" />
+    </packageSources>
+</configuration>

--- a/iMobileDevice.IntegrationTests.net45/PatchNuGet.ps1
+++ b/iMobileDevice.IntegrationTests.net45/PatchNuGet.ps1
@@ -1,0 +1,9 @@
+$version = (& $env:USERPROFILE/.nuget/packages/nerdbank.gitversioning/2.1.65/tools/Get-Version.ps1);
+
+$projectFile = Get-Content "iMobileDevice.IntegrationTests.net45.csproj"
+$projectFile = $projectFile.Replace("{imobiledevice-version}", $version.NuGetPackageVersion)
+Set-Content "iMobileDevice.IntegrationTests.net45.csproj" $projectFile
+
+$packagesFile = Get-Content "packages.config"
+$packagesFile = $packagesFile.Replace("{imobiledevice-version}", $version.NuGetPackageVersion)
+Set-Content "packages.config" $packagesFile

--- a/iMobileDevice.IntegrationTests.net45/Program.cs
+++ b/iMobileDevice.IntegrationTests.net45/Program.cs
@@ -1,0 +1,98 @@
+﻿using iMobileDevice.iDevice;
+using iMobileDevice.iDeviceActivation;
+using iMobileDevice.Lockdown;
+using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+
+namespace iMobileDevice.IntegrationTests.net45
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(typeof(NativeLibraries).Assembly.Location);
+            Console.WriteLine($"Running tests for imobiledevice-net");
+            Console.WriteLine($"- Version {fvi.FileVersion}");
+            Console.WriteLine($"- .NET 4.5");
+
+            if(Environment.Is64BitProcess)
+            {
+                Console.WriteLine("- 64-bit process");
+            }
+            else
+            {
+                Console.WriteLine("- 32-bit process");
+            }
+
+            // Make sure a call to NativeLibraries.Load() works
+            Console.WriteLine("Loading native libraries");
+            NativeLibraries.Load();
+
+            LibiMobileDevice api = new LibiMobileDevice();
+
+            // Test a method exposed in libplist
+            Console.WriteLine("libplist - Creating a property list");
+            using (var plist = api.Plist.plist_new_dict())
+            {
+            }
+
+            // Test a method exposed in libusbmuxd
+            Console.WriteLine("libusbmuxd - Set debug level");
+            api.Usbmuxd.libusbmuxd_set_debug_level(1);
+
+            // Test a method exposed in libimobiledevice
+            Console.WriteLine("libimobiledevice - Creating installation proxy options");
+            using (var options = api.InstallationProxy.instproxy_client_options_new())
+            {
+            }
+
+            // List all devices
+            Console.WriteLine("libimobiledevice - Listing devices");
+            ListDevices();
+
+            // Test a method exposed in libideviceactivation
+            Console.WriteLine("libideviceactivation - Creating a new activation request");
+            iDeviceActivationRequestHandle request;
+            api.iDeviceActivation.idevice_activation_request_new(iDeviceActivationClientType.ClientItunes, out request);
+            request.Dispose();
+
+            return 0;
+        }
+
+        static void ListDevices()
+        {
+            ReadOnlyCollection<string> udids;
+            int count = 0;
+
+            var idevice = LibiMobileDevice.Instance.iDevice;
+            var lockdown = LibiMobileDevice.Instance.Lockdown;
+
+            var ret = idevice.idevice_get_device_list(out udids, ref count);
+
+            if (ret == iDeviceError.NoDevice)
+            {
+                // Not actually an error in our case
+                return;
+            }
+
+            ret.ThrowOnError();
+
+            // Get the device name
+            foreach (var udid in udids)
+            {
+                iDeviceHandle deviceHandle;
+                idevice.idevice_new(out deviceHandle, udid).ThrowOnError();
+
+                LockdownClientHandle lockdownHandle;
+                lockdown.lockdownd_client_new_with_handshake(deviceHandle, out lockdownHandle, "Quamotion").ThrowOnError();
+
+                string deviceName;
+                lockdown.lockdownd_get_device_name(lockdownHandle, out deviceName).ThrowOnError();
+
+                deviceHandle.Dispose();
+                lockdownHandle.Dispose();
+            }
+        }
+    }
+}

--- a/iMobileDevice.IntegrationTests.net45/Properties/AssemblyInfo.cs
+++ b/iMobileDevice.IntegrationTests.net45/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("iMobileDevice.IntegrationTests.net45")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("iMobileDevice.IntegrationTests.net45")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d55760a7-6ef7-4ae6-b92b-bc87360a0d21")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/iMobileDevice.IntegrationTests.net45/iMobileDevice.IntegrationTests.net45.csproj
+++ b/iMobileDevice.IntegrationTests.net45/iMobileDevice.IntegrationTests.net45.csproj
@@ -1,0 +1,105 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D55760A7-6EF7-4AE6-B92B-BC87360A0D21}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>iMobileDevice.IntegrationTests.net45</RootNamespace>
+    <AssemblyName>iMobileDevice.IntegrationTests.net45</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="iMobileDevice-net, Version=1.2.0.0, Culture=neutral, PublicKeyToken=040ae19651fac98a, processorArchitecture=MSIL">
+      <HintPath>packages\iMobileDevice-net.{imobiledevice-version}\lib\net45\iMobileDevice-net.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="packages\iMobileDevice-net.{imobiledevice-version}\build\net45\iMobileDevice-net.targets" Condition="Exists('packages\iMobileDevice-net.{imobiledevice-version}\build\net45\iMobileDevice-net.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\iMobileDevice-net.{imobiledevice-version}\build\net45\iMobileDevice-net.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\iMobileDevice-net.{imobiledevice-version}\build\net45\iMobileDevice-net.targets'))" />
+  </Target>
+</Project>

--- a/iMobileDevice.IntegrationTests.net45/iMobileDevice.IntegrationTests.net45.sln
+++ b/iMobileDevice.IntegrationTests.net45/iMobileDevice.IntegrationTests.net45.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2003
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "iMobileDevice.IntegrationTests.net45", "iMobileDevice.IntegrationTests.net45.csproj", "{D55760A7-6EF7-4AE6-B92B-BC87360A0D21}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D55760A7-6EF7-4AE6-B92B-BC87360A0D21}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D55760A7-6EF7-4AE6-B92B-BC87360A0D21}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D55760A7-6EF7-4AE6-B92B-BC87360A0D21}.Debug|x64.ActiveCfg = Debug|x64
+		{D55760A7-6EF7-4AE6-B92B-BC87360A0D21}.Debug|x64.Build.0 = Debug|x64
+		{D55760A7-6EF7-4AE6-B92B-BC87360A0D21}.Debug|x86.ActiveCfg = Debug|x86
+		{D55760A7-6EF7-4AE6-B92B-BC87360A0D21}.Debug|x86.Build.0 = Debug|x86
+		{D55760A7-6EF7-4AE6-B92B-BC87360A0D21}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D55760A7-6EF7-4AE6-B92B-BC87360A0D21}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D55760A7-6EF7-4AE6-B92B-BC87360A0D21}.Release|x64.ActiveCfg = Release|x64
+		{D55760A7-6EF7-4AE6-B92B-BC87360A0D21}.Release|x64.Build.0 = Release|x64
+		{D55760A7-6EF7-4AE6-B92B-BC87360A0D21}.Release|x86.ActiveCfg = Release|x86
+		{D55760A7-6EF7-4AE6-B92B-BC87360A0D21}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9BD8F71D-BB90-424C-A865-416439ED394B}
+	EndGlobalSection
+EndGlobal

--- a/iMobileDevice.IntegrationTests.net45/packages.config
+++ b/iMobileDevice.IntegrationTests.net45/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="iMobileDevice-net" version="{imobiledevice-version}" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
There are a couple of reports of imobiledevice-net not working properly on .NET 4.5, so run integration tests which use the latest NuGet package (built during the CI process), and do some basic interaction with libimobiledevice. Test libplist, libusbmuxd, libimobiledevice and libideviceactivation.