### PR TITLE
Run integration tests for .NET Core 2.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ build_script:
   - dotnet test iMobileDevice.Generator.Tests\iMobileDevice.Generator.Tests.csproj
   - dotnet test iMobileDevice.Tests\iMobileDevice.Tests.csproj
 
-  # Run integration tests
+  # Run integration tests for .NET 4.5
   - mkdir packages
   - nuget init iMobileDevice-net\bin\Release\ packages
   - cd iMobileDevice.IntegrationTests.net45
@@ -69,6 +69,15 @@ build_script:
   - bin\x86\Release\iMobileDevice.IntegrationTests.net45.exe
   - bin\x64\Release\iMobileDevice.IntegrationTests.net45.exe
   - cd ..
+
+  # Run integration tests for .NET Core 2.0
+  - cd iMobileDevice.IntegrationTest.netcoreapp20
+  - powershell -File PatchCsproj.ps1
+  - dotnet run
+  - dotnet publish -r win7-x64 -c Release
+  - bin\Release\netcoreapp2.0\win7-x64\publish\iMobileDevice.IntegrationTest.netcoreapp20.exe
+  - dotnet publish -r win7-x86 -c Release
+  - bin\Release\netcoreapp2.0\win7-x86\publish\iMobileDevice.IntegrationTest.netcoreapp20.exe
 
 artifacts:
   - path: imobiledevice-net\bin\Release\imobiledevice-net.*.nupkg

--- a/iMobileDevice-net/NativeMethods.cs
+++ b/iMobileDevice-net/NativeMethods.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace iMobileDevice
 {
@@ -48,6 +45,10 @@ namespace iMobileDevice
         [DllImport(Kernel32, SetLastError = true)]
         public static extern IntPtr LoadLibrary(string dllToLoad);
 
+        [DllImport(Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool SetDllDirectory(string lpPathName);
+
         /// <summary>
         /// The function <see cref="dlopen"/> loads the dynamic library file named by the
         /// null-terminated string filename.
@@ -66,7 +67,7 @@ namespace iMobileDevice
         /// This method works on Linux only.
         /// </remarks>
         /// <seealso href="http://linux.die.net/man/3/dlopen"/>
-        [DllImport("libdl.so")]
+        [DllImport("dl")]
         public static extern IntPtr dlopen(string filename, DlOpenFlags flags);
 
         /// <summary>
@@ -83,7 +84,7 @@ namespace iMobileDevice
         /// This method works on Linux only.
         /// </remarks>
         /// <seealso href="http://linux.die.net/man/3/dlopen"/>
-        [DllImport("libdl.so")]
+        [DllImport("dl")]
         public static extern IntPtr dlerror();
     }
 }

--- a/iMobileDevice.IntegrationTest.netcoreapp20/NuGet.config
+++ b/iMobileDevice.IntegrationTest.netcoreapp20/NuGet.config
@@ -3,5 +3,6 @@
     <packageSources>
         <clear /> <!-- ensure only the sources defined below are used -->
         <add key="CI packages" value="..\packages" />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     </packageSources>
 </configuration>

--- a/iMobileDevice.IntegrationTest.netcoreapp20/NuGet.config
+++ b/iMobileDevice.IntegrationTest.netcoreapp20/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear /> <!-- ensure only the sources defined below are used -->
+        <add key="CI packages" value="..\packages" />
+    </packageSources>
+</configuration>

--- a/iMobileDevice.IntegrationTest.netcoreapp20/PatchCsproj.ps1
+++ b/iMobileDevice.IntegrationTest.netcoreapp20/PatchCsproj.ps1
@@ -1,0 +1,5 @@
+$version = (& $env:USERPROFILE/.nuget/packages/nerdbank.gitversioning/2.1.65/tools/Get-Version.ps1);
+
+$projectFile = Get-Content "iMobileDevice.IntegrationTest.netcoreapp20.csproj"
+$projectFile = $projectFile.Replace("{imobiledevice-version}", $version.NuGetPackageVersion)
+Set-Content "iMobileDevice.IntegrationTest.netcoreapp20.csproj" $projectFile

--- a/iMobileDevice.IntegrationTest.netcoreapp20/iMobileDevice.IntegrationTest.netcoreapp20.csproj
+++ b/iMobileDevice.IntegrationTest.netcoreapp20/iMobileDevice.IntegrationTest.netcoreapp20.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\iMobileDevice.IntegrationTests.net45\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="iMobileDevice-net" Version="{imobiledevice-version}" />
+  </ItemGroup>
+
+</Project>

--- a/iMobileDevice.IntegrationTest.netcoreapp20/iMobileDevice.IntegrationTest.netcoreapp20.sln
+++ b/iMobileDevice.IntegrationTest.netcoreapp20/iMobileDevice.IntegrationTest.netcoreapp20.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2003
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "iMobileDevice.IntegrationTest.netcoreapp20", "iMobileDevice.IntegrationTest.netcoreapp20.csproj", "{35C802DF-6ECA-44C8-A238-9D6CDB5A741F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{35C802DF-6ECA-44C8-A238-9D6CDB5A741F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35C802DF-6ECA-44C8-A238-9D6CDB5A741F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35C802DF-6ECA-44C8-A238-9D6CDB5A741F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35C802DF-6ECA-44C8-A238-9D6CDB5A741F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FA6E199E-14AD-4B83-9E45-A475B669BC23}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This PR adds a build steps which runs a sample console application which uses the imobiledevice-net NuGet package.

The following scenarios are tested:
- dotnet run
- dotnet publish for 64-bit windows
- dotnet publish for 32-bit windows