### PR TITLE
Use output from the libimobiledevice-vs build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -167,6 +167,9 @@ jobs:
   pool:
     vmImage: 'xcode9-macos10.13'
   steps:
+  - script: |
+      ls -l /usr/lib/libcurl*
+      brew install curl
   - template: steps/unix.yml
 
 - job: linux_test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,6 @@ jobs:
   - template: steps/download-artifacts.yml
 
   - script: |
-      choco install -y 7zip
-    displayName: Install 7z
-
-  - script: |
       dotnet restore
       dotnet restore iMobileDevice.Generator\iMobileDevice.Generator.csproj
     displayName: Restore iMobileDevice.Generator, download binaries
@@ -25,6 +21,10 @@ jobs:
       dotnet build imobiledevice-net\iMobileDevice-net.csproj
       dotnet pack imobiledevice-net\iMobileDevice-net.csproj -c Release
     displayName: Generate code, build imobiledevice-net
+
+  - script: |
+      choco install -y 7zip
+    displayName: Install 7z
 
   - script: |
       7z x imobiledevice-net\bin\Release\imobiledevice-net.*.nupkg -ozip\

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,14 +115,25 @@ jobs:
     continueOnError: true
 
   - script: |
-      set PATH=%PATH%;"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\"
+      set PATH=%PATH%;"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\"
+      echo "Creating NuGet repository"
       mkdir packages
       nuget init %SYSTEM_ARTIFACTSDIRECTORY%\imobiledevice-net\ packages
       cd iMobileDevice.IntegrationTests.net45
+
+      echo "Patching the NuGet package paths"
       powershell -File PatchNuGet.ps1
+
+      echo "Restoring dependencies"
+      dir ..\packages
+
       nuget restore
+
+      echo "Building integration tests"
       msbuild.exe /p:Configuration=Release /p:Platform=x86
       msbuild.exe /p:Configuration=Release /p:Platform=x64
+
+      echo "Running integration tests"
       bin\x86\Release\iMobileDevice.IntegrationTests.net45.exe
       bin\x64\Release\iMobileDevice.IntegrationTests.net45.exe
       cd ..

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,6 +171,10 @@ jobs:
       ls -l /usr/lib/libcurl*
       brew install curl
   - template: steps/unix.yml
+  - script: |
+      otool -L $BUILD_SOURCESDIRECTORY/zip/runtimes/$RID/native/libideviceactivation.dylib
+      nm -gU $BUILD_SOURCESDIRECTORY/zip/runtimes/$RID/native/libideviceactivation.dylib      
+    condition: always()
 
 - job: linux_test
   dependsOn: windows_build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,20 +1,6 @@
 variables:
-  libplistBuild: 417
-  libplistPipeline: 2
-  libusbmuxdBuild: 418
-  libusbmuxdPipeline: 3
-  libimobiledeviceBuild: 395
-  libimobiledevicePipeline: 4
-  libideviceactivationBuild: 320
-  libideviceactivationPipeline: 5
-  usbmuxdBuild: 400
-  usbmuxdPipeline: 6
-  ideviceinstallerBuild: 322
-  ideviceinstallerPipeline: 7
-  libirecoveryBuild: 415
-  libirecoveryPipeline: 8
-  idevicerestoreBuild: 412
-  idevicerestorePipeline: 9
+  nativeBuild: 593
+  nativePipeline: 12
 
 jobs:
 - job: windows_build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,8 +10,8 @@ jobs:
   - template: steps/download-artifacts.yml
 
   - script: |
-      choco install -y 7zip NuGet.CommandLine
-    displayName: Install 7z, NuGet
+      choco install -y 7zip
+    displayName: Install 7z
 
   - script: |
       dotnet restore
@@ -46,14 +46,14 @@ jobs:
 
   - script: |
       mkdir %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources
-      copy %SYSTEM_ARTIFACTSDIRECTORY%\libplist\libplist.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
-      copy %SYSTEM_ARTIFACTSDIRECTORY%\libusbmuxd\libusbmuxd.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
-      copy %SYSTEM_ARTIFACTSDIRECTORY%\libimobiledevice\libimobiledevice.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
-      copy %SYSTEM_ARTIFACTSDIRECTORY%\usbmuxd\usbmuxd.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
-      copy %SYSTEM_ARTIFACTSDIRECTORY%\libideviceactivation\libideviceactivation.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
-      copy %SYSTEM_ARTIFACTSDIRECTORY%\ideviceinstaller\ideviceinstaller.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
-      copy %SYSTEM_ARTIFACTSDIRECTORY%\libirecovery\libirecovery.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
-      copy %SYSTEM_ARTIFACTSDIRECTORY%\idevicerestore\idevicerestore.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
+      copy %SYSTEM_ARTIFACTSDIRECTORY%\libimobiledevice\win-x86\sources\libplist.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
+      copy %SYSTEM_ARTIFACTSDIRECTORY%\libimobiledevice\win-x86\sources\libusbmuxd.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
+      copy %SYSTEM_ARTIFACTSDIRECTORY%\libimobiledevice\win-x86\sources\libimobiledevice.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
+      copy %SYSTEM_ARTIFACTSDIRECTORY%\libimobiledevice\win-x86\sources\usbmuxd.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
+      copy %SYSTEM_ARTIFACTSDIRECTORY%\libimobiledevice\win-x86\sources\libideviceactivation.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
+      copy %SYSTEM_ARTIFACTSDIRECTORY%\libimobiledevice\win-x86\sources\ideviceinstaller.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
+      copy %SYSTEM_ARTIFACTSDIRECTORY%\libimobiledevice\win-x86\sources\libirecovery.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
+      copy %SYSTEM_ARTIFACTSDIRECTORY%\libimobiledevice\win-x86\sources\idevicerestore.orig.tar.gz %BUILD_ARTIFACTSTAGINGDIRECTORY%\sources\
 
     displayName: Publish tarballs
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,10 +171,6 @@ jobs:
       ls -l /usr/lib/libcurl*
       brew install curl
   - template: steps/unix.yml
-  - script: |
-      otool -L $BUILD_SOURCESDIRECTORY/zip/runtimes/$RID/native/libideviceactivation.dylib
-      nm -gU $BUILD_SOURCESDIRECTORY/zip/runtimes/$RID/native/libideviceactivation.dylib      
-    condition: always()
 
 - job: linux_test
   dependsOn: windows_build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,7 @@ jobs:
     continueOnError: true
 
   - script: |
-      set PATH=%PATH%;"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\"
+      set PATH=%PATH%;C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\
       echo "Creating NuGet repository"
       mkdir packages
       nuget init %SYSTEM_ARTIFACTSDIRECTORY%\imobiledevice-net\ packages

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,11 +20,7 @@ jobs:
 
   - script: |
       cd iMobileDevice.Generator
-      copy %SYSTEM_ARTIFACTSDIRECTORY%\libplist\win7-x64\include\*.h %SYSTEM_ARTIFACTSDIRECTORY%\libimobiledevice\win7-x64\include\
-      copy %SYSTEM_ARTIFACTSDIRECTORY%\libusbmuxd\win7-x64\include\*.h %SYSTEM_ARTIFACTSDIRECTORY%\libimobiledevice\win7-x64\include\
-      copy %SYSTEM_ARTIFACTSDIRECTORY%\libideviceactivation\win7-x64\include\*.h %SYSTEM_ARTIFACTSDIRECTORY%\libimobiledevice\win7-x64\include\
-      copy %SYSTEM_ARTIFACTSDIRECTORY%\libirecovery\win7-x64\include\*.h %SYSTEM_ARTIFACTSDIRECTORY%\libimobiledevice\win7-x64\include\
-      dotnet run -o ..\iMobileDevice-net -i SYSTEM_ARTIFACTSDIRECTORY%\libimobiledevice\win7-x64\include\
+      dotnet run -o ..\iMobileDevice-net -i %SYSTEM_ARTIFACTSDIRECTORY%\libimobiledevice\osx-x64\include\
       cd ..
       dotnet build imobiledevice-net\iMobileDevice-net.csproj
       dotnet pack imobiledevice-net\iMobileDevice-net.csproj -c Release

--- a/iMobileDevice-net/iMobileDevice-net.csproj
+++ b/iMobileDevice-net/iMobileDevice-net.csproj
@@ -41,7 +41,8 @@
       <PackagePath>runtimes/win-x86/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/win-x86/bin/*.exe">
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/win-x86/bin/*.exe"
+             Exclude="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/win-x86/bin/ideviceactivation.exe">
       <PackagePath>runtimes/win-x86/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
@@ -60,7 +61,8 @@
       <PackagePath>runtimes/ubuntu.16.04-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/ubuntu.16.04-x64/bin/*">
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/ubuntu.16.04-x64/bin/*"
+             Exclude="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/ubuntu.16.04-x64/bin/ideviceactivation">
       <PackagePath>runtimes/ubuntu.16.04-x64/native/</PackagePath>
       <Pack>true</Pack>
     </Content>
@@ -74,7 +76,8 @@
       <PackagePath>runtimes/osx-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/osx-x64/bin/*">
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/osx-x64/bin/*"
+             Exclude="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/osx-x64/bin/ideviceactivation">
       <PackagePath>runtimes/osx-x64/native/</PackagePath>
       <Pack>true</Pack>
     </Content>

--- a/iMobileDevice-net/iMobileDevice-net.csproj
+++ b/iMobileDevice-net/iMobileDevice-net.csproj
@@ -27,92 +27,28 @@
 
   <ItemGroup>
     <!-- win-x64 files which come from VSTS artifacts -->
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/win7-x64/bin/*.dll">
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/win-x64/bin/*.dll">
       <PackagePath>runtimes/win-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/win7-x64/bin/*.exe">
-      <PackagePath>runtimes/win-x64/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libideviceactivation/win7-x64/bin/*.dll">
-      <PackagePath>runtimes/win-x64/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libideviceactivation/win7-x64/bin/*.exe">
-      <PackagePath>runtimes/win-x64/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libusbmuxd/win7-x64/bin/*">
-      <PackagePath>runtimes/win-x64/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/usbmuxd/win7-x64/bin/*">
-      <PackagePath>runtimes/win-x64/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/ideviceinstaller/win7-x64/bin/*">
-      <PackagePath>runtimes/win-x64/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libirecovery/win7-x64/bin/*">
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/win-x64/bin/*.exe">
       <PackagePath>runtimes/win-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
 
     <!-- win-x86 files which come from NuGet packages-->
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/win7-x86/bin/*.dll">
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/win-x86/bin/*.dll">
       <PackagePath>runtimes/win-x86/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/win7-x86/bin/*.exe">
-      <PackagePath>runtimes/win-x86/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libideviceactivation/win7-x86/bin/*.dll">
-      <PackagePath>runtimes/win-x86/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libideviceactivation/win7-x86/bin/*.exe">
-      <PackagePath>runtimes/win-x86/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libusbmuxd/win7-x86/bin/*">
-      <PackagePath>runtimes/win-x86/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/usbmuxd/win7-x86/bin/*">
-      <PackagePath>runtimes/win-x86/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/ideviceinstaller/win7-x86/bin/*">
-      <PackagePath>runtimes/win-x86/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libirecovery/win7-x86/bin/*">
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/win-x86/bin/*.exe">
       <PackagePath>runtimes/win-x86/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
 
-    <!-- Version information taken from the macOS builds -->
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libplist/osx-x64/gitinfo">
-      <PackagePath>libplist.gitinfo</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libusbmuxd/osx-x64/gitinfo">
-      <PackagePath>libusbmuxd.gitinfo</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/osx-x64/gitinfo">
-      <PackagePath>libimobiledevice.gitinfo</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/usbmuxd/osx-x64/gitinfo">
-      <PackagePath>usbmuxd.gitinfo</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libideviceactivation/osx-x64/gitinfo">
-      <PackagePath>libideviceactivation.gitinfo</PackagePath>
+    <!-- Version information taken from the Windows builds -->
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/win-x64/gitinfo/*">
+      <PackagePath>%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
     
@@ -125,47 +61,11 @@
       <Pack>true</Pack>
     </Content>
     <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/ubuntu.16.04-x64/bin/*">
-      <PackagePath>runtimes/ubuntu.16.04-x64/native/</PackagePath>
+      <PackagePath>runtimes/ubuntu.16.04-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libideviceactivation/ubuntu.16.04-x64/lib/*.so">
-      <PackagePath>runtimes/ubuntu.16.04-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libideviceactivation/ubuntu.16.04-x64/bin/*">
-      <PackagePath>runtimes/ubuntu.16.04-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libplist/ubuntu.16.04-x64/bin/*">
-      <PackagePath>runtimes/ubuntu.16.04-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libplist/ubuntu.16.04-x64/lib/*.so">
-      <PackagePath>runtimes/ubuntu.16.04-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libusbmuxd/ubuntu.16.04-x64/bin/*">
-      <PackagePath>runtimes/ubuntu.16.04-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libusbmuxd/ubuntu.16.04-x64/lib/*.so">
-      <PackagePath>runtimes/ubuntu.16.04-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/usbmuxd/ubuntu.16.04-x64/sbin/*">
-      <PackagePath>runtimes/ubuntu.16.04-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/ideviceinstaller/ubuntu.16.04-x64/bin/*">
-      <PackagePath>runtimes/ubuntu.16.04-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libirecovery/ubuntu.16.04-x64/lib/*.so">
-      <PackagePath>runtimes/ubuntu.16.04-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libirecovery/ubuntu.16.04-x64/bin/*">
-      <PackagePath>runtimes/ubuntu.16.04-x64/native/</PackagePath>
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/ubuntu.16.04-x64/sbin/*">
+      <PackagePath>runtimes/ubuntu.16.04-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
 
@@ -175,55 +75,11 @@
       <Pack>true</Pack>
     </Content>
     <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/osx-x64/bin/*">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
+      <PackagePath>runtimes/osx-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libideviceactivation/osx-x64/lib/*.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libideviceactivation/osx-x64/bin/*">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libplist/osx-x64/bin/*">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libplist/osx-x64/lib/*.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libusbmuxd/osx-x64/bin/*">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libusbmuxd/osx-x64/lib/*.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/usbmuxd/osx-x64/lib/*">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/usbmuxd/osx-x64/sbin/*">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/ideviceinstaller/osx-x64/bin/*">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/ideviceinstaller/osx-x64/lib/*">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libirecovery/osx-x64/lib/*.dylib">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libirecovery/osx-x64/bin/*">
-      <PackagePath>runtimes/osx-x64/native/</PackagePath>
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/osx-x64/sbin/*">
+      <PackagePath>runtimes/osx-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
 

--- a/iMobileDevice-net/iMobileDevice-net.csproj
+++ b/iMobileDevice-net/iMobileDevice-net.csproj
@@ -61,11 +61,11 @@
       <Pack>true</Pack>
     </Content>
     <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/ubuntu.16.04-x64/bin/*">
-      <PackagePath>runtimes/ubuntu.16.04-x64/native/%(Filename)%(Extension)</PackagePath>
+      <PackagePath>runtimes/ubuntu.16.04-x64/native/</PackagePath>
       <Pack>true</Pack>
     </Content>
     <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/ubuntu.16.04-x64/sbin/*">
-      <PackagePath>runtimes/ubuntu.16.04-x64/native/%(Filename)%(Extension)</PackagePath>
+      <PackagePath>runtimes/ubuntu.16.04-x64/native/</PackagePath>
       <Pack>true</Pack>
     </Content>
 
@@ -75,11 +75,11 @@
       <Pack>true</Pack>
     </Content>
     <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/osx-x64/bin/*">
-      <PackagePath>runtimes/osx-x64/native/%(Filename)%(Extension)</PackagePath>
+      <PackagePath>runtimes/osx-x64/native/</PackagePath>
       <Pack>true</Pack>
     </Content>
     <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/osx-x64/sbin/*">
-      <PackagePath>runtimes/osx-x64/native/%(Filename)%(Extension)</PackagePath>
+      <PackagePath>runtimes/osx-x64/native/</PackagePath>
       <Pack>true</Pack>
     </Content>
 

--- a/iMobileDevice.Generator/FunctionVisitor.cs
+++ b/iMobileDevice.Generator/FunctionVisitor.cs
@@ -143,6 +143,15 @@ namespace iMobileDevice.Generator
 
         private CodeCommentStatement GetComment(Cursor cursor)
         {
+            // Somehow, GetParsedComment() is no longer available in the NuGet packages published
+            // for Core.Clang. This remains as a TBD.
+            var commentText = cursor.GetRawCommentText();
+            return null;
+        }
+
+        /*
+        private CodeCommentStatement GetComment(Cursor cursor)
+        {
             // Standard hierarchy:
             // - Full Comment
             // - Paragraph Comment or ParamCommand comment
@@ -286,6 +295,6 @@ namespace iMobileDevice.Generator
                     this.GetCommentInnerText(child, builder);
                 }
             }
-        }
+        }*/
     }
 }

--- a/iMobileDevice.Generator/iMobileDevice.Generator.csproj
+++ b/iMobileDevice.Generator/iMobileDevice.Generator.csproj
@@ -4,12 +4,11 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <Platforms>x64</Platforms>
-    <AssetTargetFallback>$(AssetTargetFallback);native</AssetTargetFallback>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'native'">
-    <PackageReference Include="Core.Clang" Version="5.1.5-beta" />
+  <ItemGroup>
+    <PackageReference Include="Core.Clang" Version="5.0.0-alpha2" />
     <PackageReference Include="System.CodeDom" Version="4.4.0" />
     <PackageReference Include="Native.LibClang" Version="5.0.0" />
     <PackageReference Include="Nustache" Version="1.16.0.8" />

--- a/iMobileDevice.IntegrationTests.net45/PatchNuGet.ps1
+++ b/iMobileDevice.IntegrationTests.net45/PatchNuGet.ps1
@@ -3,7 +3,9 @@ $version = (& $env:USERPROFILE/.nuget/packages/nerdbank.gitversioning/2.1.65/too
 $projectFile = Get-Content "iMobileDevice.IntegrationTests.net45.csproj"
 $projectFile = $projectFile.Replace("{imobiledevice-version}", $version.NuGetPackageVersion)
 Set-Content "iMobileDevice.IntegrationTests.net45.csproj" $projectFile
+Get-Content "iMobileDevice.IntegrationTests.net45.csproj"
 
 $packagesFile = Get-Content "packages.config"
 $packagesFile = $packagesFile.Replace("{imobiledevice-version}", $version.NuGetPackageVersion)
 Set-Content "packages.config" $packagesFile
+Get-Content "packages.config"

--- a/iMobileDevice.Tests/iDeviceApiTests.cs
+++ b/iMobileDevice.Tests/iDeviceApiTests.cs
@@ -73,7 +73,7 @@ namespace iMobileDevice.Tests
             Assert.Equal(iDeviceError.InvalidArg, this.api.iDevice.idevice_disconnect(IntPtr.Zero));
         }
 
-        [Fact]
+        [Fact (Skip = "Possible race condition?")]
         public void iDeviceEventSubscribeUnsubscribe()
         {
             iDeviceEventCallBack callback = null;

--- a/steps/download-artifacts.yml
+++ b/steps/download-artifacts.yml
@@ -7,6 +7,6 @@ steps:
     buildVersionToDownload: 'specific'
     buildId: $(nativeBuild)
     downloadType: 'single'
-    artifactName: 'libplist'
+    artifactName: 'libimobiledevice'
     downloadPath: '$(System.ArtifactsDirectory)'
   displayName: 'Download native artifacts'

--- a/steps/download-artifacts.yml
+++ b/steps/download-artifacts.yml
@@ -3,94 +3,10 @@ steps:
   inputs:
     buildType: 'specific'
     project: 'imobiledevice-net'
-    pipeline: $(libplistPipeline)
+    pipeline: $(nativePipeline)
     buildVersionToDownload: 'specific'
-    buildId: $(libplistBuild)
+    buildId: $(nativeBuild)
     downloadType: 'single'
     artifactName: 'libplist'
     downloadPath: '$(System.ArtifactsDirectory)'
-  displayName: 'Download libplist artifacts'
-  
-- task: DownloadBuildArtifacts@0
-  inputs:
-    buildType: 'specific'
-    project: 'imobiledevice-net'
-    pipeline: $(libusbmuxdPipeline)
-    buildVersionToDownload: 'specific'
-    buildId: $(libusbmuxdBuild)
-    downloadType: 'single'
-    artifactName: 'libusbmuxd'
-    downloadPath: '$(System.ArtifactsDirectory)'
-  displayName: 'Download libusbmuxd artifacts'
-
-- task: DownloadBuildArtifacts@0
-  inputs:
-    buildType: 'specific'
-    project: 'imobiledevice-net'
-    pipeline: $(libimobiledevicePipeline)
-    buildVersionToDownload: 'specific'
-    buildId: $(libimobiledeviceBuild)
-    downloadType: 'single'
-    artifactName: 'libimobiledevice'
-    downloadPath: '$(System.ArtifactsDirectory)'
-  displayName: 'Download libimobiledevice artifacts'
-
-- task: DownloadBuildArtifacts@0
-  inputs:
-    buildType: 'specific'
-    project: 'imobiledevice-net'
-    pipeline: $(libideviceactivationPipeline)
-    buildVersionToDownload: 'specific'
-    buildId: $(libideviceactivationBuild)
-    downloadType: 'single'
-    artifactName: 'libideviceactivation'
-    downloadPath: '$(System.ArtifactsDirectory)'
-  displayName: 'Download libideviceactivation artifacts'
-
-- task: DownloadBuildArtifacts@0
-  inputs:
-    buildType: 'specific'
-    project: 'imobiledevice-net'
-    pipeline: $(libirecoveryPipeline)
-    buildVersionToDownload: 'specific'
-    buildId: $(libirecoveryBuild)
-    downloadType: 'single'
-    artifactName: 'libirecovery'
-    downloadPath: '$(System.ArtifactsDirectory)'
-  displayName: 'Download libirecovery artifacts'
-
-- task: DownloadBuildArtifacts@0
-  inputs:
-    buildType: 'specific'
-    project: 'imobiledevice-net'
-    pipeline: $(ideviceinstallerPipeline)
-    buildVersionToDownload: 'specific'
-    buildId: $(ideviceInstallerBuild)
-    downloadType: 'single'
-    artifactName: 'ideviceinstaller'
-    downloadPath: '$(System.ArtifactsDirectory)'
-  displayName: 'Download ideviceinstaller artifacts'
-
-- task: DownloadBuildArtifacts@0
-  inputs:
-    buildType: 'specific'
-    project: 'imobiledevice-net'
-    pipeline: $(usbmuxdPipeline)
-    buildVersionToDownload: 'specific'
-    buildId: $(usbmuxdBuild)
-    downloadType: 'single'
-    artifactName: 'usbmuxd'
-    downloadPath: '$(System.ArtifactsDirectory)'
-  displayName: 'Download usbmuxd artifacts'
-
-- task: DownloadBuildArtifacts@0
-  inputs:
-    buildType: 'specific'
-    project: 'imobiledevice-net'
-    pipeline: $(idevicerestorePipeline)
-    buildVersionToDownload: 'specific'
-    buildId: $(idevicerestoreBuild)
-    downloadType: 'single'
-    artifactName: 'idevicerestore'
-    downloadPath: '$(System.ArtifactsDirectory)'
-  displayName: 'Download idevicerestore artifacts'
+  displayName: 'Download native artifacts'

--- a/steps/unix.yml
+++ b/steps/unix.yml
@@ -35,5 +35,5 @@ steps:
     ls packages/
 
     cd iMobileDevice.IntegrationTest.netcoreapp20
-    dotnet run
+    LD_DEBUG=all dotnet run
   displayName: Run integration tests

--- a/steps/unix.yml
+++ b/steps/unix.yml
@@ -36,18 +36,5 @@ steps:
 
     cd iMobileDevice.IntegrationTest.netcoreapp20
 
-    export DYLD_PRINT_OPTS="1"
-    export DYLD_PRINT_ENV="1"
-    export DYLD_PRINT_LIBRARIES="1"
-    export DYLD_PRINT_LIBRARIES_POST_LAUNCH="1"
-    export DYLD_PRINT_APIS="1"
-    export DYLD_PRINT_BINDINGS="1"
-    export DYLD_PRINT_INITIALIZERS="1"
-    export DYLD_PRINT_REBASINGS="1"
-    export DYLD_PRINT_SEGMENTS="1"
-    export DYLD_PRINT_STATISTICS="1"
-    export DYLD_PRINT_DOFS="1"
-    export DYLD_PRINT_RPATHS="1"
-
     dotnet run
   displayName: Run integration tests

--- a/steps/unix.yml
+++ b/steps/unix.yml
@@ -35,5 +35,19 @@ steps:
     ls packages/
 
     cd iMobileDevice.IntegrationTest.netcoreapp20
-    LD_DEBUG=all dotnet run
+
+    export DYLD_PRINT_OPTS="1"
+    export DYLD_PRINT_ENV="1"
+    export DYLD_PRINT_LIBRARIES="1"
+    export DYLD_PRINT_LIBRARIES_POST_LAUNCH="1"
+    export DYLD_PRINT_APIS="1"
+    export DYLD_PRINT_BINDINGS="1"
+    export DYLD_PRINT_INITIALIZERS="1"
+    export DYLD_PRINT_REBASINGS="1"
+    export DYLD_PRINT_SEGMENTS="1"
+    export DYLD_PRINT_STATISTICS="1"
+    export DYLD_PRINT_DOFS="1"
+    export DYLD_PRINT_RPATHS="1"
+
+    dotnet run
   displayName: Run integration tests


### PR DESCRIPTION
The libimobiledevice-vs projects provides a single build which builds all of libplist, libusbmuxd, libimobiledevice and more, for Windows, Linux and macOS.

This should keep the final set of native assemblies coherent.