### PR TITLE
Use Stubble to generate code

### DIFF
--- a/iMobileDevice.Generator/ModuleGenerator.cs
+++ b/iMobileDevice.Generator/ModuleGenerator.cs
@@ -4,25 +4,24 @@
 
 namespace iMobileDevice.Generator
 {
+    using CodeDom;
+    using Core.Clang;
+    using Core.Clang.Diagnostics;
+    using iMobileDevice.Generator.Nustache;
+    using Stubble.Core;
+    using Stubble.Core.Builders;
     using System;
     using System.CodeDom;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.IO;
     using System.Linq;
-#if !NETSTANDARD1_5
-    using System.Security.Permissions;
-    using System.Runtime.ConstrainedExecution;
-#endif
-    using CodeDom;
-    using Core.Clang;
-    using Core.Clang.Diagnostics;
     using System.Text;
-    using global::Nustache.Core;
-    using iMobileDevice.Generator.Nustache;
 
     public class ModuleGenerator
     {
+        private readonly StubbleVisitorRenderer stubble = new StubbleBuilder().Build();
+
         public string Name
         {
             get
@@ -274,12 +273,13 @@ namespace iMobileDevice.Generator
                 throw new ArgumentOutOfRangeException(nameof(generatedType));
             }
 
-            using (var reader = new StreamReader(generatedType.Template))
-            using (StreamWriter writer = new StreamWriter(stream, Encoding.Default, bufferSize: 4096, leaveOpen: true))
-            {
-                Render.Template(reader, generatedType.Type, writer);
-            }
+            var template = File.ReadAllText(generatedType.Template);
+            var rendered = this.stubble.Render(template, generatedType.Type);
 
+            using (StreamWriter writer = new StreamWriter(stream, Encoding.UTF8, 1024, leaveOpen: true))
+            {
+                writer.Write(rendered);
+            }
         }
 
         public void WriteType(Stream stream, CodeDomGeneratedType generatedType, string suffix)

--- a/iMobileDevice.Generator/iMobileDevice.Generator.csproj
+++ b/iMobileDevice.Generator/iMobileDevice.Generator.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Core.Clang" Version="5.0.0-alpha2" />
     <PackageReference Include="System.CodeDom" Version="4.4.0" />
     <PackageReference Include="Native.LibClang" Version="5.0.0" />
-    <PackageReference Include="Nustache" Version="1.16.0.8" />
+    <PackageReference Include="Stubble.Core" Version="1.4.12" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
     <PackageReference Include="NerdBank.GitVersioning" Version="2.1.65" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
Stubble is the successor to Nustache, and works natively on .NET Core.