### PR TITLE
Simplify build process

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,10 +24,6 @@ jobs:
     displayName: Generate code, build imobiledevice-net
 
   - script: |
-      choco install -y 7zip
-    displayName: Install 7z
-
-  - script: |
       7z x imobiledevice-net\bin\Release\imobiledevice-net.*.nupkg -ozip\
 
       mkdir %BUILD_ARTIFACTSTAGINGDIRECTORY%\imobiledevice-net
@@ -84,9 +80,8 @@ jobs:
     inputs:
       artifactName: imobiledevice-net
 
-  - script: |
-      choco install -y 7zip NuGet.CommandLine
-    displayName: Install 7z, NuGet
+  - task: NuGetToolInstaller@0
+    displayName: Install NuGet
 
   - script: |
       7z x %SYSTEM_ARTIFACTSDIRECTORY%\imobiledevice-net\iMobileDevice-net.*.nupkg -o%BUILD_SOURCESDIRECTORY%\zip

--- a/iMobileDevice.IntegrationTests.net45/PatchNuGet.ps1
+++ b/iMobileDevice.IntegrationTests.net45/PatchNuGet.ps1
@@ -1,11 +1,13 @@
-$version = (& $env:USERPROFILE/.nuget/packages/nerdbank.gitversioning/2.1.65/tools/Get-Version.ps1);
+$buildPropsPath = $env:SYSTEM_ARTIFACTSDIRECTORY + "\imobiledevice-net\Directory.Build.props"
+
+[xml]$buildProps = Get-Content $buildPropsPath
+$version = $buildProps.Project.PropertyGroup.MobileDeviceDotNetNuGetVersion
+Write-Host "Current NuGet package version: $version"
 
 $projectFile = Get-Content "iMobileDevice.IntegrationTests.net45.csproj"
-$projectFile = $projectFile.Replace("{imobiledevice-version}", $version.NuGetPackageVersion)
+$projectFile = $projectFile.Replace("{imobiledevice-version}", $version)
 Set-Content "iMobileDevice.IntegrationTests.net45.csproj" $projectFile
-Get-Content "iMobileDevice.IntegrationTests.net45.csproj"
 
 $packagesFile = Get-Content "packages.config"
-$packagesFile = $packagesFile.Replace("{imobiledevice-version}", $version.NuGetPackageVersion)
+$packagesFile = $packagesFile.Replace("{imobiledevice-version}", $version)
 Set-Content "packages.config" $packagesFile
-Get-Content "packages.config"


### PR DESCRIPTION
- Read NuGet package version from Directory.Build.props
- Don't download 7zip as it is already installed
- Don't download NuGet using chocolatey (takes up to 5 minutes), but use a pre-defined task