### PR TITLE
Various deployment fixes

### DIFF
--- a/iMobileDevice-net/iMobileDevice-net.csproj
+++ b/iMobileDevice-net/iMobileDevice-net.csproj
@@ -49,7 +49,7 @@
 
     <!-- Version information taken from the Windows builds -->
     <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/win-x64/gitinfo/*">
-      <PackagePath>%(Filename)%(Extension)</PackagePath>
+      <PackagePath>gitinfo/%(Filename)</PackagePath>
       <Pack>true</Pack>
     </Content>
     

--- a/iMobileDevice-net/iMobileDevice-net.csproj
+++ b/iMobileDevice-net/iMobileDevice-net.csproj
@@ -49,7 +49,7 @@
 
     <!-- Version information taken from the Windows builds -->
     <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libimobiledevice/win-x64/gitinfo/*">
-      <PackagePath>gitinfo/%(Filename)</PackagePath>
+      <PackagePath>gitinfo/</PackagePath>
       <Pack>true</Pack>
     </Content>
     

--- a/rpm/libimobiledevice.spec
+++ b/rpm/libimobiledevice.spec
@@ -1,0 +1,218 @@
+%{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
+
+Name:          libimobiledevice
+Version:       1.2.1.build
+Release:       6%{?dist}
+Summary:       Library for connecting to mobile devices
+
+Group:         System Environment/Libraries
+License:       LGPLv2+
+URL:           http://www.libimobiledevice.org/
+Source0:       http://www.libimobiledevice.org/downloads/%{name}-%{version}.tar.gz
+
+BuildRequires: openssl-devel
+BuildRequires: libusbx-devel
+BuildRequires: libplist-devel
+BuildRequires: glib2-devel
+BuildRequires: readline-devel
+BuildRequires: libusbmuxd-devel
+BuildRequires: swig
+
+%description
+libimobiledevice is a library for connecting to mobile devices including phones 
+and music players
+
+%package devel
+Summary: Development package for libimobiledevice
+Group: Development/Libraries
+Requires: %{name}%{?_isa} = %{version}-%{release}
+
+%description devel
+Files for development with libimobiledevice.
+
+%prep
+%setup -q
+
+%build
+./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes
+make
+
+%install
+make DESTDIR=$RPM_BUILD_ROOT install
+rm $RPM_BUILD_ROOT/usr/lib64/*.la
+
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
+%files
+%defattr(-,root,root,-)
+%doc AUTHORS COPYING.LESSER README
+%doc %{_datadir}/man/man1/idevice*
+%{_bindir}/idevice*
+%{_libdir}/libimobiledevice.so.*
+
+%files devel
+%defattr(-,root,root,-)
+%{_libdir}/pkgconfig/libimobiledevice-1.0.pc
+%{_libdir}/libimobiledevice.so
+%{_includedir}/libimobiledevice/
+
+%changelog
+* Fri Jan 24 2014 Daniel Mach <dmach@redhat.com> - 1.2.1-6
+- Mass rebuild 2014-01-24
+
+* Fri Dec 27 2013 Daniel Mach <dmach@redhat.com> - 1.2.1-5
+- Mass rebuild 2013-12-27
+
+* Tue Nov 05 2013 Bastien Nocera <bnocera@redhat.com> 1.2.1-4
+- Re-enable RPM-wide CFLAGS (regression in 1.2.1-2)
+Resolves: #884524
+
+* Mon Nov 04 2013 Bastien Nocera <bnocera@redhat.com> 1.2.1-3
+- Add missing libgcrypt BR
+Resolves: #884524
+
+* Tue Oct  8 2013 Matthias Clasen <mclasen@redhat.com> - 1.2.1-2
+- Disable strict aliasing (related: #884524)
+
+* Tue Mar 19 2013 Peter Robinson <pbrobinson@fedoraproject.org> 1.2.1-1
+- New 1.2.1 release
+
+* Thu Feb 21 2013 Bastien Nocera <bnocera@redhat.com> 1.1.4-6
+- Add patch to avoid multi-byte characters from being stripped
+  from the device name
+
+* Thu Feb 14 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.1.4-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_19_Mass_Rebuild
+
+* Wed Sep 05 2012 Bastien Nocera <bnocera@redhat.com> 1.1.4-4
+- Don't make upowerd crash when run under systemd (#834359)
+
+* Fri Aug 10 2012 Rex Dieter <rdieter@fedoraproject.org> - 1.1.4-3
+- disable broken python/cython bindings (for now, currently FTBFS)
+- track soname
+- tighten  subpkg deps
+
+* Thu Jul 19 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.1.4-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_18_Mass_Rebuild
+
+* Tue Apr 10 2012 Peter Robinson <pbrobinson@fedoraproject.org> - 1.1.4-1
+- New 1.1.4 release
+
+* Fri Jan 13 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.1.1-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_17_Mass_Rebuild
+
+* Thu Dec 08 2011 Bastien Nocera <bnocera@redhat.com> 1.1.1-4
+- All the version of Fedora are > 13 now
+
+* Thu Dec 01 2011 Bastien Nocera <bnocera@redhat.com> 1.1.1-3
+- Add iOS 5 support patches from upstream
+
+* Wed Sep 21 2011 Bastien Nocera <bnocera@redhat.com> 1.1.1-2
+- Fix compilation against recent version of gnutls
+
+* Fri Apr 29 2011 Peter Robinson <pbrobinson@gmail.com> 1.1.1-1
+- New 1.1.1 release
+
+* Tue Feb 08 2011 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.1.0-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_15_Mass_Rebuild
+
+* Sun Dec 26 2010 Bastien Nocera <bnocera@redhat.com> 1.1.0-1
+- Update to 1.1.0
+
+* Sun Nov 28 2010 Peter Robinson <pbrobinson@gmail.com> 1.0.4-1
+- New 1.0.4 release
+
+* Mon Oct  4 2010 Peter Robinson <pbrobinson@gmail.com> 1.0.3-1
+- New 1.0.3 release
+
+* Sun Aug 01 2010 Orcan Ogetbil <oget[dot]fedora[at]gmail[dot]com> - 1.0.2-3
+- Allow build against swig-2.0.0
+
+* Wed Jul 21 2010 David Malcolm <dmalcolm@redhat.com> - 1.0.2-2
+- Rebuilt for https://fedoraproject.org/wiki/Features/Python_2.7/MassRebuild
+
+* Sun Jun 20 2010 Peter Robinson <pbrobinson@gmail.com> 1.0.2-1
+- New upstream stable 1.0.2 release
+
+* Wed May 12 2010 Peter Robinson <pbrobinson@gmail.com> 1.0.1-1
+- New upstream stable 1.0.1 release
+
+* Sun Mar 21 2010 Peter Robinson <pbrobinson@gmail.com> 1.0.0-1
+- New upstream stable 1.0.0 release
+
+* Mon Feb 15 2010 Peter Robinson <pbrobinson@gmail.com> 0.9.7-3
+- Add patch to fix DSO linking. Fixes bug 565084
+
+* Wed Feb  3 2010 Peter Robinson <pbrobinson@gmail.com> 0.9.7-2
+- Package review updates, add developer docs
+
+* Wed Jan 27 2010 Peter Robinson <pbrobinson@gmail.com> 0.9.7-1
+- New package for new library name. Update to 0.9.7
+
+* Sun Jan 24 2010 Peter Robinson <pbrobinson@gmail.com> 0.9.6-1
+- Update to 0.9.6 release
+
+* Sat Jan  9 2010 Peter Robinson <pbrobinson@gmail.com> 0.9.5-3
+- Updated to the new python sysarch spec file reqs
+
+* Tue Dec 15 2009 Peter Robinson <pbrobinson@gmail.com> 0.9.5-2
+- Update python bindings
+
+* Sat Dec 12 2009 Peter Robinson <pbrobinson@gmail.com> 0.9.5-1
+- Update to 0.9.5 release for new usbmuxd/libplist 1.0.0 final
+
+* Sat Dec 12 2009 Peter Robinson <pbrobinson@gmail.com> 0.9.4-3
+- Rebuild for libplist .so bump
+
+* Wed Oct 28 2009 Peter Robinson <pbrobinson@gmail.com> 0.9.4-2
+- Update from libusb to libusb1
+
+* Wed Oct 28 2009 Peter Robinson <pbrobinson@gmail.com> 0.9.4-1
+- Update to 0.9.4 release for new usbmuxd 1.0.0-rc1
+
+* Mon Aug 10 2009 Peter Robinson <pbrobinson@gmail.com> 0.9.3-1
+- Update to 0.9.3 release
+
+* Fri Jul 24 2009 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.9.1-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_12_Mass_Rebuild
+
+* Wed May 13 2009 Peter Robinson <pbrobinson@gmail.com> 0.9.1-2
+- Add new build reqs
+
+* Tue May 12 2009 Peter Robinson <pbrobinson@gmail.com> 0.9.1-1
+- Update to official 0.9.1 release
+
+* Fri Apr 03 2009 - Bastien Nocera <bnocera@redhat.com> - 0.1.0-11.20090325git443edc8
+- Update to latest master version
+
+* Wed Feb 25 2009 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.1.0-10.20090103git5cde554
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_11_Mass_Rebuild
+
+* Sat Jan 3 2009 Peter Robinson <pbrobinson@gmail.com> 0.1.0-9.git5cde554
+- Add back gnutls version patch
+
+* Sat Jan 3 2009 Peter Robinson <pbrobinson@gmail.com> 0.1.0-8.git5cde554
+- Upload bzipped source file
+
+* Sat Jan 3 2009 Peter Robinson <pbrobinson@gmail.com> 0.1.0-7.git5cde554
+- New git snapshot
+
+* Mon Dec 8 2008 Peter Robinson <pbrobinson@gmail.com> 0.1.0-6.git8c3a01e
+- Fix devel dependency 
+
+* Mon Dec 8 2008 Peter Robinson <pbrobinson@gmail.com> 0.1.0-5.git8c3a01e
+- Fix gnutls check for new rawhide version
+
+* Mon Dec 8 2008 Peter Robinson <pbrobinson@gmail.com> 0.1.0-4.git8c3a01e
+- Rebuild for pkgconfig
+
+* Tue Dec 2 2008 Peter Robinson <pbrobinson@gmail.com> 0.1.0-3.git8c3a01e
+- Fix git file generation
+
+* Mon Dec 1 2008 Peter Robinson <pbrobinson@gmail.com> 0.1.0-2.git8c3a01e
+- Updates for package review
+
+* Sat Nov 29 2008 Peter Robinson <pbrobinson@gmail.com> 0.1.0-1
+- Initial package

--- a/rpm/libplist.spec
+++ b/rpm/libplist.spec
@@ -1,0 +1,157 @@
+%{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
+
+Name:          libplist
+Version:       2.0.1.build
+Release:       0%{?dist}
+Summary:       Library for manipulating Apple Binary and XML Property Lists
+
+Group:         System Environment/Libraries
+License:       LGPLv2+
+URL:           http://www.libimobiledevice.org/
+Source0:       http://www.libimobiledevice.org/downloads/%{name}-%{version}.tar.gz
+
+BuildRequires: swig
+BuildRequires: gcc-c++
+
+%description
+libplist is a library for manipulating Apple Binary and XML Property Lists
+
+%package devel
+Summary: Development package for libplist
+Group: Development/Libraries
+Requires: libplist = %{version}-%{release}
+Requires: pkgconfig
+
+%description devel
+%{name}, development headers and libraries.
+
+%prep
+%setup -q
+
+%build
+./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes
+make
+
+%install
+make DESTDIR=$RPM_BUILD_ROOT install
+rm $RPM_BUILD_ROOT/usr/lib64/*.la
+
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
+%files
+%defattr(-,root,root,-)
+%doc AUTHORS COPYING.LESSER README
+%{_bindir}/plistutil
+%{_libdir}/libplist.so.*
+%{_libdir}/libplist++.so.*
+
+%files devel
+%defattr(-,root,root,-)
+%{_libdir}/pkgconfig/libplist.pc
+%{_libdir}/pkgconfig/libplist++.pc
+%{_libdir}/libplist.so
+%{_libdir}/libplist++.so
+%{_includedir}/plist
+
+%changelog
+* Fri Jan 24 2014 Daniel Mach <dmach@redhat.com> - 1.10-4
+- Mass rebuild 2014-01-24
+
+* Fri Dec 27 2013 Daniel Mach <dmach@redhat.com> - 1.10-3
+- Mass rebuild 2013-12-27
+
+* Tue Oct  8 2013 Matthias Clasen <mclasen@redhat.com> - 1.10-2
+- Disable strict aliasing (related: #884099)
+
+* Tue Mar 19 2013 Peter Robinson <pbrobinson@fedoraproject.org> 1.10-1
+- New upstream 1.10 release
+
+* Mon Mar 18 2013 Peter Robinson <pbrobinson@fedoraproject.org> 1.9-1
+- New upstream 1.9 release
+
+* Thu Feb 14 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.8-6
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_19_Mass_Rebuild
+
+* Thu Jul 19 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.8-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_18_Mass_Rebuild
+
+* Wed Apr 11 2012 Peter Robinson <pbrobinson@fedoraproject.org> - 1.8-4
+- Fix python bindings
+
+* Wed Apr 11 2012 Rex Dieter <rdieter@fedoraproject.org> 1.8-3
+- fix ftbfs, work harder to ensure CMAKE_INSTALL_LIBDIR macro is correct 
+
+* Fri Mar 23 2012 Peter Robinson <pbrobinson@fedoraproject.org> - 1.8-2
+- Fix RPATH issue with cmake, disable parallel build as it causes other problems
+
+* Thu Jan 12 2012 Peter Robinson <pbrobinson@fedoraproject.org> - 1.8-1
+- 1.8 release
+
+* Mon Sep 26 2011 Peter Robinson <pbrobinson@fedoraproject.org> - 1.7-1
+- 1.7 release
+
+* Sat Jun 25 2011 Peter Robinson <pbrobinson@fedoraproject.org> 1.6-1
+- 1.6 release
+
+* Mon Jun 13 2011 Peter Robinson <pbrobinson@fedoraproject.org> 1.5-1
+- 1.5 release
+
+* Tue Mar 22 2011 Peter Robinson <pbrobinson@fedoraproject.org> 1.4-1
+- stable 1.4 release
+
+* Tue Feb 08 2011 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.3-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_15_Mass_Rebuild
+
+* Wed Jul 21 2010 David Malcolm <dmalcolm@redhat.com> - 1.3-2
+- Rebuilt for https://fedoraproject.org/wiki/Features/Python_2.7/MassRebuild
+
+* Tue Apr 20 2010 Peter Robinson <pbrobinson@fedoraproject.org> 1.3-1
+- Upstream stable 1.3 release
+
+* Sat Jan 23 2010 Peter Robinson <pbrobinson@fedoraproject.org> 1.2-1
+- Upstream stable 1.2 release
+
+* Sat Jan  9 2010 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.0-5
+- Updated to the new python sysarch spec file reqs
+
+* Mon Dec  7 2009 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.0-4
+- and once more with feeling
+
+* Mon Dec  7 2009 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.0-3
+- Further updated fixes for the spec file
+
+* Mon Dec  7 2009 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.0-2
+- Drop upstreamed patch
+
+* Mon Dec  7 2009 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.0-1
+- Upstream stable 1.0.0 release
+
+* Thu Oct 29 2009 Peter Robinson <pbrobinson@fedoraproject.org> 0.16-3
+- Actually add patch for python
+
+* Thu Oct 29 2009 Peter Robinson <pbrobinson@fedoraproject.org> 0.16-2
+- Add python patch and c++ bindings
+
+* Thu Oct 29 2009 Peter Robinson <pbrobinson@fedoraproject.org> 0.16-1
+- New upstream 0.16 release
+
+* Tue Oct 20 2009 Peter Robinson <pbrobinson@fedoraproject.org> 0.15-1
+- New upstream 0.15 release
+
+* Fri Jul 24 2009 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.13-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_12_Mass_Rebuild
+
+* Mon May 11 2009 Peter Robinson <pbrobinson@fedoraproject.org> 0.13-1
+- New upstream 0.13 release
+
+* Mon May 11 2009 Peter Robinson <pbrobinson@fedoraproject.org> 0.12-2
+- Further review updates
+
+* Sun May 10 2009 Peter Robinson <pbrobinson@fedoraproject.org> 0.12-1
+- Update to official tarball release, some review fixes
+
+* Sun May 10 2009 Peter Robinson <pbrobinson@fedoraproject.org> 0.12.0-0.1
+- Initial package
+

--- a/rpm/libusbmuxd.spec
+++ b/rpm/libusbmuxd.spec
@@ -1,0 +1,59 @@
+%{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
+
+Name:          libusbmuxd
+Version:       1.1.0.build
+Release:       0%{?dist}
+Summary:       Library for the USB multiplexor daemon for iPhone and iPod Touch devices
+
+Group:         System Environment/Libraries
+License:       LGPLv2+
+URL:           http://www.libimobiledevice.org/
+Source0:       http://www.libimobiledevice.org/downloads/%{name}-%{version}.tar.gz
+
+BuildRequires: swig
+BuildRequires: gcc-c++
+BuildRequires: libplist-devel
+
+%description
+libusbmuxd is a library for the USB multiplexor daemon for iPhone and iPod Touch
+
+%package devel
+Summary: Development package for libusbmuxd
+Group: Development/Libraries
+Requires: libusbmuxd = %{version}-%{release}
+Requires: pkgconfig
+
+%description devel
+%{name}, development headers and libraries.
+
+%prep
+%setup -q
+
+%build
+./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes
+make
+
+%install
+make DESTDIR=$RPM_BUILD_ROOT install
+rm $RPM_BUILD_ROOT/usr/lib64/*.la
+
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
+%files
+%defattr(-,root,root,-)
+%doc AUTHORS COPYING README
+%{_bindir}/iproxy
+%{_libdir}/libusbmuxd.so.*
+
+%files devel
+%defattr(-,root,root,-)
+%{_libdir}/pkgconfig/libusbmuxd.pc
+%{_libdir}/libusbmuxd.so
+%{_includedir}/*.h
+
+%changelog
+* Fri Apr 21 2017 Frederik Carlier <frederik.carlier@quamotion.mobi> - 1.1.0-4
+- Initial package
+

--- a/rpm/usbmuxd.spec
+++ b/rpm/usbmuxd.spec
@@ -1,0 +1,171 @@
+Name:          usbmuxd
+Version:       1.1.0.build
+Release:       11%{?dist}
+Summary:       Daemon for communicating with Apple's iOS devices
+
+Group:         Applications/System
+# All code is dual licenses as GPLv3+ or GPLv2+, except libusbmuxd which is LGPLv2+.
+License:       GPLv3+ or GPLv2+ and LGPLv2+
+URL:           http://www.libimobiledevice.org/
+Source0:       http://www.libimobiledevice.org/downloads/%{name}-%{version}.tar.gz
+
+BuildRequires: libplist-devel
+BuildRequires: libusbx-devel
+BuildRequires: libusbmuxd-devel
+BuildRequires: libimobiledevice-devel
+BuildRequires: gcc-c++
+# For the systemd RPM macros
+BuildRequires: systemd
+Requires(pre): shadow-utils
+Requires(post): systemd-units
+Requires(preun): systemd-units
+Requires(postun): systemd-units
+
+%description
+usbmuxd is a daemon used for communicating with Apple's iPod Touch, iPhone, 
+iPad and Apple TV devices. It allows multiple services on the device to be 
+accessed simultaneously.
+
+%prep
+%setup -q
+
+# Set the owner of the device node to be usbmuxd
+sed -i.owner 's/OWNER="usbmux"/OWNER="usbmuxd"/' udev/39-usbmuxd.rules.in
+sed -i.user 's/--user usbmux/--user usbmuxd/' systemd/usbmuxd.service.in
+
+%build
+./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes
+make
+
+%install
+export CMAKE_PREFIX_PATH=/usr$RPM_BUILD_ROOT
+make install DESTDIR=$RPM_BUILD_ROOT
+
+%pre
+getent group usbmuxd >/dev/null || groupadd -r usbmuxd -g 113
+getent passwd usbmuxd >/dev/null || \
+useradd -r -g usbmuxd -d / -s /sbin/nologin \
+	-c "usbmuxd user" -u 113 usbmuxd
+exit 0
+
+%post
+/sbin/ldconfig
+%systemd_post usbmuxd.service
+
+%preun
+%systemd_preun usbmuxd.service
+
+%postun
+/sbin/ldconfig
+%systemd_postun_with_restart usbmuxd.service 
+
+%files
+%doc AUTHORS README COPYING.GPLv2 COPYING.GPLv3
+/usr/share/man/man8/usbmuxd.8.gz
+/usr/lib/udev/rules.d/39-usbmuxd.rules
+/usr/lib/systemd/system/usbmuxd.service
+%{_sbindir}/usbmuxd
+
+%changelog
+* Fri Jan 24 2014 Daniel Mach <dmach@redhat.com> - 1.0.8-11
+- Mass rebuild 2014-01-24
+
+* Fri Dec 27 2013 Daniel Mach <dmach@redhat.com> - 1.0.8-10
+- Mass rebuild 2013-12-27
+
+* Wed Nov 06 2013 Bastien Nocera <bnocera@redhat.com> 1.0.8-9
+- Add BR so scriptlets are expanded
+Resolves: #1017894
+
+* Mon Nov  4 2013 Matthias Clasen <mclasen@redhat.com> - 1.0.8-8
+- Fix %%postun scriptlet
+- Resolves: #1017894 
+
+* Fri Feb 15 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.0.8-7
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_19_Mass_Rebuild
+
+* Mon Nov 19 2012 Bastien Nocera <bnocera@redhat.com> 1.0.8-6
+- Fix source URL
+
+* Thu Oct  4 2012 Peter Robinson <pbrobinson@fedoraproject.org> - 1.0.8-5
+- Make use of the new systemd macros
+- Minor updates to spec
+
+* Sun Jul 22 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.0.8-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_18_Mass_Rebuild
+
+* Mon Jul 09 2012 Bastien Nocera <bnocera@redhat.com> 1.0.8-3
+- Use systemd to start usbmuxd instead of udev (#786853)
+
+* Sat Apr 28 2012 Bastien Nocera <bnocera@redhat.com> 1.0.8-2
+- Fix usbmuxd not starting under udev
+
+* Mon Apr  9 2012 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.8-1
+- New stable 1.0.8 release
+
+* Thu Feb  2 2012 Peter Robinson <pbrobinson@fedoraproject.org> - 1.0.7-3
+- Add debian patch for CVE-2012-0065. Fixes RHBZ 783523
+
+* Sat Jan 14 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.0.7-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_17_Mass_Rebuild
+
+* Tue Mar 22 2011 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.7-1
+- New stable 1.0.7 release
+
+* Mon Feb 07 2011 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.0.6-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_15_Mass_Rebuild
+
+* Sun Oct 24 2010 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.6-1
+- New stable 1.0.6 release
+
+* Fri Jul 23 2010 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.5-1
+- New stable 1.0.5 release
+
+* Fri May 28 2010 Bastien Nocera <bnocera@redhat.com> 1.0.4-3
+- Fix udev rule to use the usbmuxd user
+
+* Wed May 12 2010 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.4-2
+- Actually upload a source file
+
+* Tue May 11 2010 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.4-1
+- New stable 1.0.4 release
+
+* Mon Mar 22 2010 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.3-1
+- New stable 1.0.3 release
+
+* Thu Feb 11 2010 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.2-1
+- New stable 1.0.2 release
+
+* Tue Feb 09 2010 Bastien Nocera <bnocera@redhat.com> 1.0.0-3
+- Use the gid/uid reserved for usbmuxd in setup 2.8.15 and above
+
+* Fri Jan 29 2010 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.0-2
+- Run deamon under the usbmuxd user
+
+* Mon Dec  7 2009 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.0-1
+- New stable 1.0.0 release
+
+* Sat Oct 31 2009 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.0-0.1.rc2
+- New 1.0.0-rc2 test release
+
+* Thu Oct 29 2009 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.0-0.2.rc1
+- Add patch to fix install of 64 bit libs
+
+* Tue Oct 27 2009 Peter Robinson <pbrobinson@fedoraproject.org> 1.0.0-0.1.rc1
+- New 1.0.0-rc1 test release
+
+* Fri Aug 14 2009 Bastien Nocera <bnocera@redhat.com> 0.1.4-2
+- Make usbmuxd autostart on newer kernels
+- (Still doesn't exit properly though)
+
+* Mon Aug 10 2009 Peter Robinson <pbrobinson@fedoraproject.org> 0.1.4-1
+- Update to 0.1.4
+
+* Tue Aug  4 2009 Peter Robinson <pbrobinson@fedoraproject.org> 0.1.3-1
+- Update to 0.1.3, review input
+
+* Mon Aug  3 2009 Peter Robinson <pbrobinson@fedoraproject.org> 0.1.2-1
+- Update to 0.1.2
+
+* Mon Aug  3 2009 Peter Robinson <pbrobinson@fedoraproject.org> 0.1.1-1
+- Initial packaging

--- a/steps/deploy-docker.yml
+++ b/steps/deploy-docker.yml
@@ -1,14 +1,7 @@
 steps:
 - task: DownloadBuildArtifacts@0
   inputs:
-    buildType: 'specific'
-    project: 'imobiledevice-net'
-    pipeline: $(imobiledevicenetPipeline)
-    buildVersionToDownload: 'specific'
-    buildId: $(imobiledevicenetBuild)
-    downloadType: 'single'
     artifactName: 'imobiledevice-net'
-    downloadPath: '$(System.ArtifactsDirectory)'
   displayName: 'Download imobiledevice-net artifacts'
 - script: |
     sudo apt-get install -y libxml2-utils

--- a/steps/deploy-github.yml
+++ b/steps/deploy-github.yml
@@ -1,25 +1,11 @@
 steps:
 - task: DownloadBuildArtifacts@0
   inputs:
-    buildType: 'specific'
-    project: 'imobiledevice-net'
-    pipeline: $(imobiledevicenetPipeline)
-    buildVersionToDownload: 'specific'
-    buildId: $(imobiledevicenetBuild)
-    downloadType: 'single'
     artifactName: 'imobiledevice-net'
-    downloadPath: '$(System.ArtifactsDirectory)'
   displayName: 'Download imobiledevice-net artifacts'
 - task: DownloadBuildArtifacts@0
   inputs:
-    buildType: 'specific'
-    project: 'imobiledevice-net'
-    pipeline: $(imobiledevicenetPipeline)
-    buildVersionToDownload: 'specific'
-    buildId: $(imobiledevicenetBuild)
-    downloadType: 'single'
     artifactName: 'binaries'
-    downloadPath: '$(System.ArtifactsDirectory)'
   displayName: 'Download binary artifacts'
 - script: |
     wget https://github.com/buildkite/github-release/releases/download/v1.0/github-release-linux-amd64 -O github-release
@@ -29,11 +15,11 @@ steps:
 
     unzip $SYSTEM_ARTIFACTSDIRECTORY/imobiledevice-net/iMobileDevice-net.*.nupkg
 
-    libplist_commit=`cat libplist.gitinfo/gitinfo | tail -n 1`
-    libusbmuxd_commit=`cat libusbmuxd.gitinfo/gitinfo | tail -n 1`
-    libimobiledevice_commit=`cat libimobiledevice.gitinfo/gitinfo | tail -n 1`
-    usbmuxd_commit=`cat usbmuxd.gitinfo/gitinfo | tail -n 1`
-    libideviceactivation_commit=`cat libideviceactivation.gitinfo/gitinfo | tail -n 1`
+    libplist_commit=`cat gitinfo/libplist | tail -n 1`
+    libusbmuxd_commit=`cat gitinfo/libusbmuxd | tail -n 1`
+    libimobiledevice_commit=`cat gitinfo/libimobiledevice | tail -n 1`
+    usbmuxd_commit=`cat gitinfo/usbmuxd | tail -n 1`
+    libideviceactivation_commit=`cat gitinfo/libideviceactivation | tail -n 1`
     imobiledevice_net_commit=$BUILD_SOURCEVERSION
     version_number=`xmllint --xpath 'Project/PropertyGroup/MobileDeviceDotNetNuGetVersion/text()' $SYSTEM_ARTIFACTSDIRECTORY/imobiledevice-net/Directory.Build.props`
 

--- a/steps/deploy-nuget.yml
+++ b/steps/deploy-nuget.yml
@@ -1,14 +1,8 @@
 steps:
 - task: DownloadBuildArtifacts@0
   inputs:
-    buildType: 'specific'
-    project: 'imobiledevice-net'
     pipeline: $(imobiledevicenetPipeline)
-    buildVersionToDownload: 'specific'
-    buildId: $(imobiledevicenetBuild)
-    downloadType: 'single'
     artifactName: 'imobiledevice-net'
-    downloadPath: '$(System.ArtifactsDirectory)'
   displayName: 'Download imobiledevice-net artifacts'
 - task: NuGetCommand@2
   continueOnError: true


### PR DESCRIPTION
- Add RPM `.spec` files (which can be used later to send to OSC)
- Fix artifact names used in deploy paths
- Fix the paths to the `gitinfo` files; everything should now be in `/gitinfo/`