### PR TITLE
Update native package

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -197,7 +197,7 @@ stages:
           DIST: bionic
         disco:
           DIST: disco
-        disco:
+        eoan:
           DIST: eoan
     pool:
       vmImage: 'ubuntu-16.04'
@@ -247,7 +247,7 @@ stages:
           DIST: bionic
         disco:
           DIST: disco
-        disco:
+        eoan:
           DIST: eoan
     pool:
       vmImage: 'ubuntu-16.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -197,6 +197,8 @@ stages:
           DIST: bionic
         disco:
           DIST: disco
+        disco:
+          DIST: eoan
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
@@ -245,6 +247,8 @@ stages:
           DIST: bionic
         disco:
           DIST: disco
+        disco:
+          DIST: eoan
     pool:
       vmImage: 'ubuntu-16.04'
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -193,15 +193,26 @@ stages:
       matrix:
         xenial:
           DIST: xenial
+          imageName: ubuntu:16.04
         bionic:
           DIST: bionic
+          imageName: ubuntu:18.04
         disco:
           DIST: disco
+          imageName: ubuntu:19.04
         eoan:
           DIST: eoan
+          imageName: ubuntu:19.10
     pool:
       vmImage: 'ubuntu-16.04'
+    container:
+      image: $(imageName)
+      options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
     steps:
+    - script: |
+        /tmp/docker exec -t -u 0 ci-container \
+        sh -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
+      displayName: Set up sudo
     - template: steps/create-deb.yml
 
 - stage: Deploy

--- a/rpm/libimobiledevice.spec
+++ b/rpm/libimobiledevice.spec
@@ -16,7 +16,6 @@ BuildRequires: libplist-devel
 BuildRequires: glib2-devel
 BuildRequires: readline-devel
 BuildRequires: libusbmuxd-devel
-BuildRequires: swig
 
 %description
 libimobiledevice is a library for connecting to mobile devices including phones 
@@ -34,7 +33,7 @@ Files for development with libimobiledevice.
 %setup -q -n libimobiledevice
 
 %build
-./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes
+./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes --without-cython
 make
 
 %install

--- a/rpm/libimobiledevice.spec
+++ b/rpm/libimobiledevice.spec
@@ -16,6 +16,7 @@ BuildRequires: libplist-devel
 BuildRequires: glib2-devel
 BuildRequires: readline-devel
 BuildRequires: libusbmuxd-devel
+BuildRequires: gdb
 
 %description
 libimobiledevice is a library for connecting to mobile devices including phones 

--- a/rpm/libimobiledevice.spec
+++ b/rpm/libimobiledevice.spec
@@ -33,7 +33,7 @@ Files for development with libimobiledevice.
 %setup -q -n libimobiledevice
 
 %build
-./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes --without-cython
+./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes
 make
 
 %install

--- a/rpm/libplist.spec
+++ b/rpm/libplist.spec
@@ -10,7 +10,6 @@ License:       LGPLv2+
 URL:           http://www.libimobiledevice.org/
 Source0:       http://www.libimobiledevice.org/downloads/%{name}-%{version}.tar.gz
 
-BuildRequires: swig
 BuildRequires: gcc-c++
 
 %description
@@ -29,7 +28,7 @@ Requires: pkgconfig
 %setup -q -n libplist
 
 %build
-./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes
+./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes --without-cython
 make
 
 %install

--- a/rpm/libplist.spec
+++ b/rpm/libplist.spec
@@ -11,6 +11,7 @@ URL:           http://www.libimobiledevice.org/
 Source0:       http://www.libimobiledevice.org/downloads/%{name}-%{version}.tar.gz
 
 BuildRequires: gcc-c++
+BuildRequires: gdb
 
 %description
 libplist is a library for manipulating Apple Binary and XML Property Lists
@@ -28,7 +29,7 @@ Requires: pkgconfig
 %setup -q -n libplist
 
 %build
-./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes --without-cython
+./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes
 make
 
 %install

--- a/rpm/libusbmuxd.spec
+++ b/rpm/libusbmuxd.spec
@@ -29,7 +29,7 @@ Requires: pkgconfig
 %setup -q -n libusbmuxd
 
 %build
-./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes --without-cython
+./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes
 make
 
 %install

--- a/rpm/libusbmuxd.spec
+++ b/rpm/libusbmuxd.spec
@@ -10,7 +10,6 @@ License:       LGPLv2+
 URL:           http://www.libimobiledevice.org/
 Source0:       http://www.libimobiledevice.org/downloads/%{name}-%{version}.tar.gz
 
-BuildRequires: swig
 BuildRequires: gcc-c++
 BuildRequires: libplist-devel
 
@@ -30,7 +29,7 @@ Requires: pkgconfig
 %setup -q -n libusbmuxd
 
 %build
-./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes
+./autogen.sh --prefix=/usr --without-cython --libdir=/usr/lib64 --enable-static=no --enable-shared=yes --without-cython
 make
 
 %install

--- a/rpm/libusbmuxd.spec
+++ b/rpm/libusbmuxd.spec
@@ -11,6 +11,7 @@ URL:           http://www.libimobiledevice.org/
 Source0:       http://www.libimobiledevice.org/downloads/%{name}-%{version}.tar.gz
 
 BuildRequires: gcc-c++
+BuildRequires: gdb
 BuildRequires: libplist-devel
 
 %description

--- a/rpm/usbmuxd.spec
+++ b/rpm/usbmuxd.spec
@@ -14,6 +14,7 @@ BuildRequires: libusbx-devel
 BuildRequires: libusbmuxd-devel
 BuildRequires: libimobiledevice-devel
 BuildRequires: gcc-c++
+BuildRequires: gdb
 # For the systemd RPM macros
 BuildRequires: systemd
 Requires(pre): shadow-utils

--- a/steps/create-deb.yml
+++ b/steps/create-deb.yml
@@ -8,10 +8,9 @@ steps:
     artifactName: 'sources'
   displayName: 'Download imobiledevice-net artifacts'
 - script: |
-    sudo add-apt-repository ppa:quamotion/ppa
     sudo apt-get update
-    sudo apt-get install -y libplist-dev libplist++-dev libusbmuxd-dev libimobiledevice-dev libusb-1.0-0-dev libreadline-dev libcurl4-openssl-dev
-    sudo apt-get install -y libxml2-utils devscripts debhelper dh-autoreconf dput cython python-all-dev doxygen
+    sudo apt-get install -y libusb-1.0-0-dev libreadline-dev libcurl4-openssl-dev libssl-dev pkg-config libjs-jquery libglib2.0-dev libtasn1-6-dev udev systemd libxml2-dev
+    sudo apt-get install -y libxml2-utils devscripts debhelper dh-autoreconf dput cython python-all-dev doxygen chrpath
     sudo apt-get install -y libzip-dev
   displayName: 'Install dependencies'
 - script: |
@@ -44,6 +43,8 @@ steps:
         debuild -S -uc -us
 
         cd ..
+
+        sudo dpkg -i $package*.deb
     done
 
     cp *.* $BUILD_ARTIFACTSTAGINGDIRECTORY/deb/

--- a/steps/create-deb.yml
+++ b/steps/create-deb.yml
@@ -44,7 +44,7 @@ steps:
 
         cd ..
 
-        if [ "$package" -ne "ios-webkit-debug-proxy" ]
+        if [ "$package" != "ios-webkit-debug-proxy" ]
         then
           sudo dpkg -i $package*.deb
         fi

--- a/steps/create-deb.yml
+++ b/steps/create-deb.yml
@@ -44,7 +44,10 @@ steps:
 
         cd ..
 
-        sudo dpkg -i $package*.deb
+        if [ "$package" -ne "ios-webkit-debug-proxy" ]
+        then
+          sudo dpkg -i $package*.deb
+        fi
     done
 
     cp *.* $BUILD_ARTIFACTSTAGINGDIRECTORY/deb/


### PR DESCRIPTION
- Add support for Ubuntu Eoan (19.10)
- Remove dependency on the swig package, which is not available in CentOS 8 and was only used to create the cython bindings (which are not being built)
- Add explicit dependency on gdb to unblock aarch64 builds on Fedora
- Build Ubuntu deb packages in Docker containers running that version of Ubuntu