### PR TITLE
Bump to native build 1056

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  nativeBuild: 1056
+  nativeBuild: 1062
   nativePipeline: 12
   runTests: true
   createDeb: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  nativeBuild: 1025
+  nativeBuild: 1056
   nativePipeline: 12
   runTests: true
   createDeb: true

--- a/deb/libideviceactivation/debian/libideviceactivation.symbols
+++ b/deb/libideviceactivation/debian/libideviceactivation.symbols
@@ -1,4 +1,4 @@
-libideviceactivation.so.2 libideviceactivation #MINVER#
+libideviceactivation-1.0.so.2 libideviceactivation #MINVER#
  idevice_activation_drm_handshake_request_new@Base 1.0.0.25
  idevice_activation_request_free@Base 1.0.0.25
  idevice_activation_request_get_field@Base 1.0.0.25

--- a/deb/libimobiledevice/debian/libimobiledevice6.symbols
+++ b/deb/libimobiledevice/debian/libimobiledevice6.symbols
@@ -1,4 +1,4 @@
-libimobiledevice.so.6 libimobiledevice6 #MINVER#
+libimobiledevice-1.0.so.6 libimobiledevice6 #MINVER#
  afc_client_free@Base 0.9.7
  afc_client_new@Base 0.9.7
  afc_client_new_from_house_arrest_client@Base 1.1.0

--- a/deb/libplist/debian/libplist++-dev.install
+++ b/deb/libplist/debian/libplist++-dev.install
@@ -1,4 +1,4 @@
-usr/lib/*/libplist++.so
+usr/lib/*/libplist++-2.0.so
 usr/include/plist/Structure.h
 usr/include/plist/Real.h
 usr/include/plist/String.h

--- a/deb/libplist/debian/libplist++3v5.install
+++ b/deb/libplist/debian/libplist++3v5.install
@@ -1,1 +1,1 @@
-usr/lib/*/libplist-2.0++.so.3*
+usr/lib/*/libplist++-2.0.so.3*

--- a/deb/libplist/debian/libplist++3v5.install
+++ b/deb/libplist/debian/libplist++3v5.install
@@ -1,1 +1,1 @@
-usr/lib/*/libplist++.so.3*
+usr/lib/*/libplist-2.0++.so.3*

--- a/deb/libplist/debian/libplist++3v5.symbols
+++ b/deb/libplist/debian/libplist++3v5.symbols
@@ -1,4 +1,4 @@
-libplist++.so.3 libplist++3v5 #MINVER#
+libplist-2.0++.so.3 libplist++3v5 #MINVER#
 # (c++)"PList::Dictionary::GetNodeKey[abi:cxx11](PList::Node*)@Base" 1.12
 # (c++)"PList::Dictionary::End[abi:cxx11]()@Base" 1.12
 # (c++)"PList::Dictionary::Begin[abi:cxx11]()@Base" 1.12

--- a/deb/libplist/debian/libplist++3v5.symbols
+++ b/deb/libplist/debian/libplist++3v5.symbols
@@ -1,4 +1,4 @@
-libplist-2.0++.so.3 libplist++3v5 #MINVER#
+libplist++-2.0.so.3 libplist++3v5 #MINVER#
 # (c++)"PList::Dictionary::GetNodeKey[abi:cxx11](PList::Node*)@Base" 1.12
 # (c++)"PList::Dictionary::End[abi:cxx11]()@Base" 1.12
 # (c++)"PList::Dictionary::Begin[abi:cxx11]()@Base" 1.12

--- a/deb/libplist/debian/libplist-dev.install
+++ b/deb/libplist/debian/libplist-dev.install
@@ -1,3 +1,3 @@
-usr/lib/*/libplist.so
+usr/lib/*/libplist-2.0.so
 usr/include/plist/plist.h
 usr/lib/*/pkgconfig/libplist-2.0.pc

--- a/deb/libplist/debian/libplist3.install
+++ b/deb/libplist/debian/libplist3.install
@@ -1,1 +1,1 @@
-usr/lib/*/libplist.so.3*
+usr/lib/*/libplist-2.0.so.3*

--- a/deb/libplist/debian/libplist3.symbols
+++ b/deb/libplist/debian/libplist3.symbols
@@ -1,4 +1,4 @@
-libplist.so.3 libplist3 #MINVER#
+libplist-2.0.so.3 libplist3 #MINVER#
  plist_access_path@Base 1.11
  plist_access_pathv@Base 1.11
  plist_array_append_item@Base 1.11

--- a/iMobileDevice-net/LibraryResolver.cs
+++ b/iMobileDevice-net/LibraryResolver.cs
@@ -50,7 +50,15 @@ namespace iMobileDevice
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                if (NativeLibrary.TryLoad("libplist.so.3", out lib))
+                if (NativeLibrary.TryLoad("libplist-2.0.so.3", out lib))
+                {
+                    return lib;
+                }
+                else if (NativeLibrary.TryLoad("libplist-2.0.so", out lib))
+                {
+                    return lib;
+                }
+                else if (NativeLibrary.TryLoad("libplist.so.3", out lib))
                 {
                     return lib;
                 }
@@ -62,7 +70,11 @@ namespace iMobileDevice
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                if (NativeLibrary.TryLoad("libplist.dylib", out lib))
+                if (NativeLibrary.TryLoad("libplist-2.0.dylib", out lib))
+                {
+                    return lib;
+                }
+                else if (NativeLibrary.TryLoad("libplist.dylib", out lib))
                 {
                     return lib;
                 }
@@ -109,7 +121,15 @@ namespace iMobileDevice
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                if (NativeLibrary.TryLoad("libimobiledevice.so.6", out lib))
+                if (NativeLibrary.TryLoad("libimobiledevice-1.0.so.6", out lib))
+                {
+                    return lib;
+                }
+                else if (NativeLibrary.TryLoad("libimobiledevice-1.0.so", out lib))
+                {
+                    return lib;
+                }
+                else if (NativeLibrary.TryLoad("libimobiledevice.so.6", out lib))
                 {
                     return lib;
                 }
@@ -121,7 +141,11 @@ namespace iMobileDevice
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                if (NativeLibrary.TryLoad("libimobiledevice.dylib", out lib))
+                if (NativeLibrary.TryLoad("libimobiledevice-1.0.dylib", out lib))
+                {
+                    return lib;
+                }
+                else if (NativeLibrary.TryLoad("libimobiledevice.dylib", out lib))
                 {
                     return lib;
                 }
@@ -136,7 +160,15 @@ namespace iMobileDevice
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                if (NativeLibrary.TryLoad("libideviceactivation.so.2", out lib))
+                if (NativeLibrary.TryLoad("libideviceactivation-1.0.so.2", out lib))
+                {
+                    return lib;
+                }
+                else if (NativeLibrary.TryLoad("libideviceactivation-1.0.so", out lib))
+                {
+                    return lib;
+                }
+                else if (NativeLibrary.TryLoad("libideviceactivation.so.2", out lib))
                 {
                     return lib;
                 }
@@ -148,7 +180,11 @@ namespace iMobileDevice
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                if (NativeLibrary.TryLoad("libideviceactivation.dylib", out lib))
+                if (NativeLibrary.TryLoad("libideviceactivation-1.0.dylib", out lib))
+                {
+                    return lib;
+                }
+                else if (NativeLibrary.TryLoad("libideviceactivation.dylib", out lib))
                 {
                     return lib;
                 }

--- a/iMobileDevice-net/LibraryResolver.cs
+++ b/iMobileDevice-net/LibraryResolver.cs
@@ -50,19 +50,19 @@ namespace iMobileDevice
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                if (NativeLibrary.TryLoad("libplist-2.0.so.3", out lib))
+                if (NativeLibrary.TryLoad("libplist-2.0.so.3", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
-                else if (NativeLibrary.TryLoad("libplist-2.0.so", out lib))
+                else if (NativeLibrary.TryLoad("libplist-2.0.so", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
-                else if (NativeLibrary.TryLoad("libplist.so.3", out lib))
+                else if (NativeLibrary.TryLoad("libplist.so.3", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
-                else if (NativeLibrary.TryLoad("libplist.so", out lib))
+                else if (NativeLibrary.TryLoad("libplist.so", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
@@ -70,11 +70,11 @@ namespace iMobileDevice
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                if (NativeLibrary.TryLoad("libplist-2.0.dylib", out lib))
+                if (NativeLibrary.TryLoad("libplist-2.0.dylib", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
-                else if (NativeLibrary.TryLoad("libplist.dylib", out lib))
+                else if (NativeLibrary.TryLoad("libplist.dylib", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
@@ -89,16 +89,16 @@ namespace iMobileDevice
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                if (NativeLibrary.TryLoad("libusbmuxd.so.6", out lib))
+                if (NativeLibrary.TryLoad("libusbmuxd.so.6", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
-                else if (NativeLibrary.TryLoad("libusbmuxd.so.4", out lib))
+                else if (NativeLibrary.TryLoad("libusbmuxd.so.4", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     // Not all symbols will be available in libusbmuxd.so.4
                     return lib;
                 }
-                else if (NativeLibrary.TryLoad("libusbmuxd.so", out lib))
+                else if (NativeLibrary.TryLoad("libusbmuxd.so", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
@@ -106,7 +106,7 @@ namespace iMobileDevice
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                if (NativeLibrary.TryLoad("libusbmuxd.dylib", out lib))
+                if (NativeLibrary.TryLoad("libusbmuxd.dylib", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
@@ -121,19 +121,19 @@ namespace iMobileDevice
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                if (NativeLibrary.TryLoad("libimobiledevice-1.0.so.6", out lib))
+                if (NativeLibrary.TryLoad("libimobiledevice-1.0.so.6", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
-                else if (NativeLibrary.TryLoad("libimobiledevice-1.0.so", out lib))
+                else if (NativeLibrary.TryLoad("libimobiledevice-1.0.so", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
-                else if (NativeLibrary.TryLoad("libimobiledevice.so.6", out lib))
+                else if (NativeLibrary.TryLoad("libimobiledevice.so.6", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
-                else if (NativeLibrary.TryLoad("libimobiledevice.so", out lib))
+                else if (NativeLibrary.TryLoad("libimobiledevice.so", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
@@ -141,11 +141,11 @@ namespace iMobileDevice
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                if (NativeLibrary.TryLoad("libimobiledevice-1.0.dylib", out lib))
+                if (NativeLibrary.TryLoad("libimobiledevice-1.0.dylib", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
-                else if (NativeLibrary.TryLoad("libimobiledevice.dylib", out lib))
+                else if (NativeLibrary.TryLoad("libimobiledevice.dylib", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
@@ -160,19 +160,19 @@ namespace iMobileDevice
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                if (NativeLibrary.TryLoad("libideviceactivation-1.0.so.2", out lib))
+                if (NativeLibrary.TryLoad("libideviceactivation-1.0.so.2", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
-                else if (NativeLibrary.TryLoad("libideviceactivation-1.0.so", out lib))
+                else if (NativeLibrary.TryLoad("libideviceactivation-1.0.so", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
-                else if (NativeLibrary.TryLoad("libideviceactivation.so.2", out lib))
+                else if (NativeLibrary.TryLoad("libideviceactivation.so.2", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
-                else if (NativeLibrary.TryLoad("libideviceactivation.so", out lib))
+                else if (NativeLibrary.TryLoad("libideviceactivation.so", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
@@ -180,11 +180,11 @@ namespace iMobileDevice
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                if (NativeLibrary.TryLoad("libideviceactivation-1.0.dylib", out lib))
+                if (NativeLibrary.TryLoad("libideviceactivation-1.0.dylib", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }
-                else if (NativeLibrary.TryLoad("libideviceactivation.dylib", out lib))
+                else if (NativeLibrary.TryLoad("libideviceactivation.dylib", Assembly.GetExecutingAssembly(), null, out lib))
                 {
                     return lib;
                 }

--- a/iMobileDevice-net/NativeLibraries.cs
+++ b/iMobileDevice-net/NativeLibraries.cs
@@ -150,7 +150,7 @@ namespace iMobileDevice
 
                 string[] linuxLibariesToLoad = new string[]
                     {
-                        "libimobiledevice",
+                        "libimobiledevice-1.0",
                     };
 
                 // Clear any value from dlerror

--- a/iMobileDevice-net/NativeLibraries.cs
+++ b/iMobileDevice-net/NativeLibraries.cs
@@ -75,6 +75,8 @@ namespace iMobileDevice
             isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
             isMacOs = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+            LibraryResolver.EnsureRegistered();
 #else
             switch (Environment.OSVersion.Platform)
             {

--- a/steps/unix.yml
+++ b/steps/unix.yml
@@ -36,5 +36,7 @@ steps:
 
     cd iMobileDevice.IntegrationTests.netcoreapp30
 
+    export LD_DEBUG=libs
+    export DYLD_PRINT_LIBRARIES=1
     dotnet run
   displayName: Run integration tests


### PR DESCRIPTION
- Fixes a regression where usbmuxd would default to USB configuration 4
- This includes the new releases for most libimobiledevice libraries, which, amongst others, now include the version number in their library names.