### PR TITLE
Bump versions to match upstream releases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  nativeBuild: 1062
+  nativeBuild: 1076
   nativePipeline: 12
   runTests: true
   createDeb: true

--- a/rpm/libideviceactivation.spec
+++ b/rpm/libideviceactivation.spec
@@ -1,5 +1,5 @@
 Name:          libideviceactivation 
-Version:       1.0.1.build
+Version:       1.1.2.build
 Release:       6%{?dist}
 Summary:       A library to manage the activation process of Apple iOS devices.
 

--- a/rpm/libimobiledevice.spec
+++ b/rpm/libimobiledevice.spec
@@ -1,7 +1,7 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 
 Name:          libimobiledevice
-Version:       1.2.2.build
+Version:       1.3.1.build
 Release:       6%{?dist}
 Summary:       Library for connecting to mobile devices
 

--- a/rpm/libplist.spec
+++ b/rpm/libplist.spec
@@ -1,7 +1,7 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 
 Name:          libplist
-Version:       2.1.1.build
+Version:       2.2.1.build
 Release:       0%{?dist}
 Summary:       Library for manipulating Apple Binary and XML Property Lists
 

--- a/steps/create-deb.yml
+++ b/steps/create-deb.yml
@@ -25,7 +25,7 @@ steps:
     cd $SYSTEM_ARTIFACTSDIRECTORY/sources/
 
     declare -A package_versions
-    package_versions=( ["libplist"]="2.2.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.3.1" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.0.1" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
+    package_versions=( ["libplist"]="2.2.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.3.1" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.1.2" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
 
     for package in libplist libusbmuxd libimobiledevice usbmuxd libideviceactivation ideviceinstaller ios-webkit-debug-proxy
     do

--- a/steps/create-deb.yml
+++ b/steps/create-deb.yml
@@ -25,7 +25,7 @@ steps:
     cd $SYSTEM_ARTIFACTSDIRECTORY/sources/
 
     declare -A package_versions
-    package_versions=( ["libplist"]="2.1.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.2.2" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.0.1" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
+    package_versions=( ["libplist"]="2.2.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.2.2" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.0.1" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
 
     for package in libplist libusbmuxd libimobiledevice usbmuxd libideviceactivation ideviceinstaller ios-webkit-debug-proxy
     do

--- a/steps/create-deb.yml
+++ b/steps/create-deb.yml
@@ -25,7 +25,7 @@ steps:
     cd $SYSTEM_ARTIFACTSDIRECTORY/sources/
 
     declare -A package_versions
-    package_versions=( ["libplist"]="2.2.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.2.2" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.0.1" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
+    package_versions=( ["libplist"]="2.2.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.3.1" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.0.1" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
 
     for package in libplist libusbmuxd libimobiledevice usbmuxd libideviceactivation ideviceinstaller ios-webkit-debug-proxy
     do

--- a/steps/deploy-osc.yml
+++ b/steps/deploy-osc.yml
@@ -29,7 +29,7 @@ steps:
 
     declare -A package_versions
 
-    package_versions=( ["libplist"]="2.1.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.2.2" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.0.1" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
+    package_versions=( ["libplist"]="2.2.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.2.2" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.0.1" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
 
     for package in libplist libusbmuxd libimobiledevice usbmuxd libideviceactivation ideviceinstaller ios-webkit-debug-proxy
     do

--- a/steps/deploy-osc.yml
+++ b/steps/deploy-osc.yml
@@ -29,7 +29,7 @@ steps:
 
     declare -A package_versions
 
-    package_versions=( ["libplist"]="2.2.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.3.1" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.0.1" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
+    package_versions=( ["libplist"]="2.2.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.3.1" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.1.2" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
 
     for package in libplist libusbmuxd libimobiledevice usbmuxd libideviceactivation ideviceinstaller ios-webkit-debug-proxy
     do

--- a/steps/deploy-osc.yml
+++ b/steps/deploy-osc.yml
@@ -29,7 +29,7 @@ steps:
 
     declare -A package_versions
 
-    package_versions=( ["libplist"]="2.2.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.2.2" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.0.1" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
+    package_versions=( ["libplist"]="2.2.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.3.1" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.0.1" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
 
     for package in libplist libusbmuxd libimobiledevice usbmuxd libideviceactivation ideviceinstaller ios-webkit-debug-proxy
     do

--- a/steps/deploy-ppa.yml
+++ b/steps/deploy-ppa.yml
@@ -28,7 +28,7 @@ steps:
     cd $SYSTEM_ARTIFACTSDIRECTORY/deb/
 
     declare -A package_versions
-    package_versions=( ["libplist"]="2.2.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.2.2" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.0.1" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
+    package_versions=( ["libplist"]="2.2.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.3.1" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.0.1" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
 
     for package in libplist libusbmuxd libimobiledevice usbmuxd libideviceactivation ideviceinstaller ios-webkit-debug-proxy
     do

--- a/steps/deploy-ppa.yml
+++ b/steps/deploy-ppa.yml
@@ -28,7 +28,7 @@ steps:
     cd $SYSTEM_ARTIFACTSDIRECTORY/deb/
 
     declare -A package_versions
-    package_versions=( ["libplist"]="2.2.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.3.1" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.0.1" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
+    package_versions=( ["libplist"]="2.2.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.3.1" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.1.2" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
 
     for package in libplist libusbmuxd libimobiledevice usbmuxd libideviceactivation ideviceinstaller ios-webkit-debug-proxy
     do

--- a/steps/deploy-ppa.yml
+++ b/steps/deploy-ppa.yml
@@ -28,7 +28,7 @@ steps:
     cd $SYSTEM_ARTIFACTSDIRECTORY/deb/
 
     declare -A package_versions
-    package_versions=( ["libplist"]="2.1.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.2.2" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.0.1" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
+    package_versions=( ["libplist"]="2.2.1" ["libusbmuxd"]="2.0.3" ["libimobiledevice"]="1.2.2" ["usbmuxd"]="1.1.2" ["libideviceactivation"]="1.0.1" ["ideviceinstaller"]="1.1.3" ["ios-webkit-debug-proxy"]="1.8.6")
 
     for package in libplist libusbmuxd libimobiledevice usbmuxd libideviceactivation ideviceinstaller ios-webkit-debug-proxy
     do

--- a/steps/test-deb.yml
+++ b/steps/test-deb.yml
@@ -18,12 +18,12 @@ steps:
     set -e
     version_number=`xmllint --xpath 'Project/PropertyGroup/MobileDeviceDotNetNuGetVersion/text()' $SYSTEM_ARTIFACTSDIRECTORY/imobiledevice-net/Directory.Build.props`
 
-    sudo apt install -y $SYSTEM_ARTIFACTSDIRECTORY/deb/libplist3_2.1.1-${version_number}-0${DIST}_amd64.deb
+    sudo apt install -y $SYSTEM_ARTIFACTSDIRECTORY/deb/libplist3_2.2.1-${version_number}-0${DIST}_amd64.deb
     sudo apt install -y $SYSTEM_ARTIFACTSDIRECTORY/deb/libusbmuxd6_2.0.3-${version_number}-0${DIST}_amd64.deb
     sudo apt install -y $SYSTEM_ARTIFACTSDIRECTORY/deb/libusbmuxd-tools_2.0.3-${version_number}-0${DIST}_amd64.deb
-    sudo apt install -y $SYSTEM_ARTIFACTSDIRECTORY/deb/libimobiledevice6_1.2.2-${version_number}-0${DIST}_amd64.deb
-    sudo apt install -y $SYSTEM_ARTIFACTSDIRECTORY/deb/libimobiledevice-utils_1.2.2-${version_number}-0${DIST}_amd64.deb
-    sudo apt install -y $SYSTEM_ARTIFACTSDIRECTORY/deb/libideviceactivation_1.0.1-${version_number}-0${DIST}_amd64.deb
+    sudo apt install -y $SYSTEM_ARTIFACTSDIRECTORY/deb/libimobiledevice6_1.3.1-${version_number}-0${DIST}_amd64.deb
+    sudo apt install -y $SYSTEM_ARTIFACTSDIRECTORY/deb/libimobiledevice-utils_1.3.1-${version_number}-0${DIST}_amd64.deb
+    sudo apt install -y $SYSTEM_ARTIFACTSDIRECTORY/deb/libideviceactivation_1.1.2-${version_number}-0${DIST}_amd64.deb
     sudo apt install -y $SYSTEM_ARTIFACTSDIRECTORY/deb/ideviceinstaller_1.1.3-${version_number}-0${DIST}_amd64.deb
   displayName: Install Debian archives
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2",
+  "version": "1.3",
   "publicReleaseRefSpec": [
     "^refs/heads/master$"
   ]


### PR DESCRIPTION
- Bump version numbers to match upstream releases
- Bump native build to get an updated version of ios-webkit-debug-proxy which build with libimobiledevice-1.0